### PR TITLE
Add basic service client

### DIFF
--- a/selvpc/doc.go
+++ b/selvpc/doc.go
@@ -1,0 +1,25 @@
+/*
+Package selvpc provides a library to work with the Selectel VPC API.
+
+Authentication
+
+To work with the Selectel VPC API you first need to:
+
+- create a Selectel account: https://my.selectel.ru/registration
+- obtain an API token: http://my.selectel.ru/profile/apikeys
+
+You can then provide the API token to the selvpc service client.
+
+Service clients
+
+Service client is a special struct that implements a client for different part
+of the Selectel VPC API.
+You need to initialize the needed service client prior to do any requests:
+
+	token := "token_string"
+	resellClient := resell.NewV2ResellClient(token)
+
+All methods of service clients uses the Go context to provide end-user of the
+library with a native way to work with the cancelation signals
+*/
+package selvpc

--- a/selvpc/selvpc.go
+++ b/selvpc/selvpc.go
@@ -1,0 +1,89 @@
+package selvpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+const (
+	// AppVersion is a version of the application.
+	AppVersion = "1.0.0"
+
+	// DefaultEndpoint contains basic endpoint for queries.
+	DefaultEndpoint = "https://api.selectel.ru/vpc"
+
+	// DefaultUserAgent contains basic user agent that will be used in queries.
+	DefaultUserAgent = "selvpc/" + AppVersion
+)
+
+// ServiceClient stores details that are needed to work with different Selectel VPC APIs.
+type ServiceClient struct {
+	// HTTPClient represents an initialized HTTP client that will be used to do requests.
+	HTTPClient *http.Client
+
+	// Endpoint represents an enpoint that will be used in all requests.
+	Endpoint string
+
+	// TokenID is a client authentication token.
+	TokenID string
+
+	// UserAgent contains user agent that will be used in all requests.
+	UserAgent string
+}
+
+// ResponseResult represents a result of a HTTP request.
+// It embeddes standard http.Response and adds a custom error description.
+type ResponseResult struct {
+	*http.Response
+
+	// Err contains error that can be provided to a caller.
+	Err error
+}
+
+// DoRequest performs the HTTP request with the current ServiceClient's HTTPClient.
+// Authentication and optional headers will be automatically added.
+func (client *ServiceClient) DoRequest(ctx context.Context, method, url string, body io.Reader) (*ResponseResult, error) {
+	// Prepare a HTTP request with the provided context.
+	request, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("User-Agent", client.UserAgent)
+	request.Header.Set("X-token", client.TokenID)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	request = request.WithContext(ctx)
+
+	// Send HTTP request and populate the ResponseResult.
+	response, err := client.HTTPClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	responseResult := &ResponseResult{
+		response,
+		nil,
+	}
+	if response.StatusCode >= 400 && response.StatusCode <= 599 {
+		err = fmt.Errorf("selvpc: got the %d error status code from the server", response.StatusCode)
+		responseResult.Err = err
+	}
+
+	return responseResult, nil
+}
+
+// ExtractResult allow to provide an object into which ResponseResult body will be extracted.
+func (result *ResponseResult) ExtractResult(to interface{}) error {
+	body, err := ioutil.ReadAll(result.Body)
+	defer result.Body.Close()
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(body, to)
+	return err
+}

--- a/selvpc/testing/client_test.go
+++ b/selvpc/testing/client_test.go
@@ -1,0 +1,96 @@
+package testing
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/selectel/go-selvpcclient/selvpc"
+
+	"github.com/selectel/go-selvpcclient/selvpc/testutils"
+)
+
+func TestDoGetRequest(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, "response")
+
+		if r.Method != "GET" {
+			t.Errorf("got %s method, want GET", r.Method)
+		}
+	})
+
+	endpoint := testEnv.Server.URL + "/"
+	client := &selvpc.ServiceClient{
+		HTTPClient: &http.Client{},
+		Endpoint:   endpoint,
+		TokenID:    "token",
+		UserAgent:  "agent",
+	}
+
+	ctx := context.Background()
+	response, err := client.DoRequest(ctx, "GET", endpoint, nil)
+	if err != nil {
+		log.Fatalf("unexpected error: %v", err)
+	}
+	if response.Body == nil {
+		log.Fatalf("response body is empty")
+	}
+	if response.StatusCode != 200 {
+		log.Fatalf("got %d response status, want 200", response.StatusCode)
+	}
+}
+
+func TestDoPostRequest(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, "response")
+
+		if r.Method != "POST" {
+			t.Errorf("got %s method, want POST", r.Method)
+		}
+
+		_, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("unable to read the request body: %v", err)
+		}
+	})
+
+	endpoint := testEnv.Server.URL + "/"
+	client := &selvpc.ServiceClient{
+		HTTPClient: &http.Client{},
+		Endpoint:   endpoint,
+		TokenID:    "token",
+		UserAgent:  "agent",
+	}
+
+	requestBody, err := json.Marshal(&struct {
+		ID string `json:"id"`
+	}{
+		ID: "uuid",
+	})
+	if err != nil {
+		log.Fatalf("can't marshal JSON: %v", err)
+	}
+
+	ctx := context.Background()
+	response, err := client.DoRequest(ctx, "POST", endpoint, bytes.NewReader(requestBody))
+	if err != nil {
+		log.Fatalf("unexpected error: %v", err)
+	}
+	if response.Body == nil {
+		log.Fatalf("response body is empty")
+	}
+	if response.StatusCode != 200 {
+		log.Fatalf("got %d response status, want 200", response.StatusCode)
+	}
+}

--- a/selvpc/testutils/environment.go
+++ b/selvpc/testutils/environment.go
@@ -1,0 +1,35 @@
+package testutils
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/selectel/go-selvpcclient/selvpc"
+)
+
+// TestEnv represents a testing environment for all resources.
+type TestEnv struct {
+	Mux    *http.ServeMux
+	Server *httptest.Server
+	Client *selvpc.ServiceClient
+}
+
+// SetupTestEnv prepares the new testing environmenœt.
+func SetupTestEnv() *TestEnv {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	testEnv := &TestEnv{
+		Mux:    mux,
+		Server: server,
+	}
+
+	return testEnv
+}
+
+// TearDownTestEnv releases the testing environment.
+func (testEnv *TestEnv) TearDownTestEnv() {
+	testEnv.Server.Close()
+	testEnv.Server = nil
+	testEnv.Mux = nil
+	testEnv.Client = nil
+}

--- a/selvpc/testutils/fakes.go
+++ b/selvpc/testutils/fakes.go
@@ -1,0 +1,4 @@
+package testutils
+
+// FakeTokenID is a fake token for the Selectel VPC API.
+const FakeTokenID = "fakeUUID"


### PR DESCRIPTION
Add client with basic methods and structures that will be used by all
subpackages of the selvpc library.

For #1.