### PR TITLE
Add the Resell v2 service client

### DIFF
--- a/selvpc/resell/doc.go
+++ b/selvpc/resell/doc.go
@@ -1,0 +1,5 @@
+/*
+Package resell provides all needed method and structures to work with the
+Selectel VPC Resell API.
+*/
+package resell

--- a/selvpc/resell/resell.go
+++ b/selvpc/resell/resell.go
@@ -1,0 +1,11 @@
+package resell
+
+import "github.com/selectel/go-selvpcclient/selvpc"
+
+const (
+	// Endpoint contains the base url for all versions of the Resell client.
+	Endpoint = selvpc.DefaultEndpoint + "/resell"
+
+	// UserAgent contains the user agent for all versions of the Resell client.
+	UserAgent = selvpc.DefaultUserAgent
+)

--- a/selvpc/resell/v2/client.go
+++ b/selvpc/resell/v2/client.go
@@ -1,0 +1,23 @@
+package v2
+
+import (
+	"net/http"
+
+	"github.com/selectel/go-selvpcclient/selvpc"
+	"github.com/selectel/go-selvpcclient/selvpc/resell"
+)
+
+// APIVersion sets the version of the Resell client.
+const APIVersion = "v2"
+
+// NewV2ResellClient initializes a new Resell client for the V2 API.
+func NewV2ResellClient(TokenID string) *selvpc.ServiceClient {
+	resellClient := &selvpc.ServiceClient{
+		HTTPClient: &http.Client{},
+		Endpoint:   resell.Endpoint + "/" + APIVersion,
+		TokenID:    TokenID,
+		UserAgent:  resell.UserAgent,
+	}
+
+	return resellClient
+}

--- a/selvpc/resell/v2/doc.go
+++ b/selvpc/resell/v2/doc.go
@@ -1,0 +1,4 @@
+/*
+Package v2 provides methods and structures to work with the Resell V2 API.
+*/
+package v2

--- a/selvpc/testutils/clients.go
+++ b/selvpc/testutils/clients.go
@@ -1,0 +1,20 @@
+package testutils
+
+import (
+	"net/http"
+
+	"github.com/selectel/go-selvpcclient/selvpc"
+	"github.com/selectel/go-selvpcclient/selvpc/resell"
+)
+
+// NewTestResellV2Client prepares a client for the Resell V2 API tests.
+func (testEnv *TestEnv) NewTestResellV2Client() {
+	apiVersion := "v2"
+	resellClient := &selvpc.ServiceClient{
+		HTTPClient: &http.Client{},
+		Endpoint:   testEnv.Server.URL + "/resell/" + apiVersion,
+		TokenID:    FakeTokenID,
+		UserAgent:  resell.UserAgent,
+	}
+	testEnv.Client = resellClient
+}


### PR DESCRIPTION
Add service client for the Resell v2 API. Also provide a test client  that can be used with unit tests.

For #4.