### PR TITLE
Add Resell V2 user create method

### DIFF
--- a/selvpcclient/resell/v2/users/doc.go
+++ b/selvpcclient/resell/v2/users/doc.go
@@ -11,5 +11,17 @@ Example of getting all users
   for _, user := range allUsers {
     fmt.Println(user)
   }
+
+Example of creating a single user
+
+  userCreateOpts := users.UserOpts{
+    Name:     "user0",
+    Password: "verysecret",
+  }
+  createdUser, _, err := users.Create(ctx, resellClient, userCreateOpts)
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Println(createdUser)
 */
 package users

--- a/selvpcclient/resell/v2/users/requests.go
+++ b/selvpcclient/resell/v2/users/requests.go
@@ -1,7 +1,9 @@
 package users
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
 
 	"github.com/selectel/go-selvpcclient/selvpcclient"
@@ -30,4 +32,37 @@ func List(ctx context.Context, client *selvpcclient.ServiceClient) ([]*User, *se
 	}
 
 	return result.Users, responseResult, nil
+}
+
+// Create requests a creation of the user.
+func Create(ctx context.Context, client *selvpcclient.ServiceClient, createOpts UserOpts) (*User, *selvpcclient.ResponseResult, error) {
+	// Nest create options into the parent "user" JSON structure.
+	type createProject struct {
+		Options UserOpts `json:"user"`
+	}
+	createProjectOpts := &createProject{Options: createOpts}
+	requestBody, err := json.Marshal(createProjectOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
+	responseResult, err := client.DoRequest(ctx, "POST", url, bytes.NewReader(requestBody))
+	if err != nil {
+		return nil, nil, err
+	}
+	if responseResult.Err != nil {
+		return nil, responseResult, responseResult.Err
+	}
+
+	// Extract a user from the response body.
+	var result struct {
+		User *User `json:"user"`
+	}
+	err = responseResult.ExtractResult(&result)
+	if err != nil {
+		return nil, responseResult, err
+	}
+
+	return result.User, responseResult, nil
 }

--- a/selvpcclient/resell/v2/users/requests_opts.go
+++ b/selvpcclient/resell/v2/users/requests_opts.go
@@ -1,0 +1,13 @@
+package users
+
+// UserOpts represents options for the user Create and Update requests.
+type UserOpts struct {
+	// Name represents the name of a user.
+	Name string `json:"name,omitempty"`
+
+	// Password represents a user's password.
+	Password string `json:"password,omitempty"`
+
+	// Enabled shows if user is active or it was disabled.
+	Enabled *bool `json:"enabled,omitempty"`
+}

--- a/selvpcclient/resell/v2/users/testing/fixtures.go
+++ b/selvpcclient/resell/v2/users/testing/fixtures.go
@@ -41,3 +41,37 @@ var TestListUsersSingleUserResponse = []*users.User{
 		ID:      "4b2e452ed4c940bd87a88499eaf14c4f",
 	},
 }
+
+// TestCreateUserOptsRaw represents marshalled options for the Create request.
+const TestCreateUserOptsRaw = `
+{
+    "user": {
+        "name": "NewUser1",
+        "password":"verysecret"
+    }
+}
+`
+
+// TestCreateUserOpts represent options for the Create request.
+var TestCreateUserOpts = users.UserOpts{
+	Name:     "NewUser1",
+	Password: "verysecret",
+}
+
+// TestCreateUserResponseRaw represents a raw response from the Create request.
+const TestCreateUserResponseRaw = `
+{
+    "user": {
+        "enabled": true,
+        "name": "NewUser1",
+        "id": "4b2e452ed4c940bd87a88499eaf14c4f"
+    }
+}
+`
+
+// TestCreateUserResponse represents the unmarshalled TestCreateUserResponseRaw response.
+var TestCreateUserResponse = &users.User{
+	ID:      "4b2e452ed4c940bd87a88499eaf14c4f",
+	Name:    "NewUser1",
+	Enabled: true,
+}

--- a/selvpcclient/resell/v2/users/testing/requests_test.go
+++ b/selvpcclient/resell/v2/users/testing/requests_test.go
@@ -2,7 +2,9 @@ package testing
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
@@ -57,5 +59,49 @@ func TestListUsersSingle(t *testing.T) {
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("expected %#v, but got %#v", expected, actual)
+	}
+}
+
+func TestCreateUser(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.NewTestResellV2Client()
+	testEnv.Mux.HandleFunc("/resell/v2/users", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, TestCreateUserResponseRaw)
+
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("unable to read the request body: %v", err)
+		}
+
+		var actualRequest interface{}
+		err = json.Unmarshal(b, &actualRequest)
+		if err != nil {
+			t.Errorf("unable to unmarshal the request body: %v", err)
+		}
+
+		var expectedRequest interface{}
+		err = json.Unmarshal([]byte(TestCreateUserOptsRaw), &expectedRequest)
+		if err != nil {
+			t.Errorf("unable to unmarshal expected raw response: %v", err)
+		}
+
+		if !reflect.DeepEqual(actualRequest, expectedRequest) {
+			t.Fatalf("expected %#v create options, but got %#v", expectedRequest, actualRequest)
+		}
+	})
+
+	ctx := context.Background()
+	createOpts := TestCreateUserOpts
+	actualResponse, _, err := users.Create(ctx, testEnv.Client, createOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedResponse := TestCreateUserResponse
+
+	if !reflect.DeepEqual(actualResponse, expectedResponse) {
+		t.Fatalf("expected %#v, but got %#v", actualResponse, expectedResponse)
 	}
 }


### PR DESCRIPTION
Add method to create a Resell V2 user.
Add structure with user create options, docs example and test.

For #17 
