### PR TITLE
Add Resell V2 floating ip GET method

### DIFF
--- a/selvpcclient/resell/v2/floatingips/doc.go
+++ b/selvpcclient/resell/v2/floatingips/doc.go
@@ -2,6 +2,14 @@
 Package floatingips provides the ability to retrieve and manage floatingips through
 the Resell v2 API.
 
+Example of getting a single floating ip referenced by its id
+
+  floatingip, _, err := floatingips.Get(context, resellClient, fipID)
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Println(floatingip)
+
 Example of getting all floatingips
 
   allFloatingIPs, _, err := floatingips.List(ctx, resellClient)

--- a/selvpcclient/resell/v2/floatingips/requests.go
+++ b/selvpcclient/resell/v2/floatingips/requests.go
@@ -9,6 +9,29 @@ import (
 
 const resourceURL = "floatingips"
 
+// Get returns a single floating ip by its id.
+func Get(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*FloatingIP, *selvpcclient.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
+	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if responseResult.Err != nil {
+		return nil, responseResult, responseResult.Err
+	}
+
+	// Extract a floating ip from the response body.
+	var result struct {
+		FloatingIP *FloatingIP `json:"floatingip"`
+	}
+	err = responseResult.ExtractResult(&result)
+	if err != nil {
+		return nil, responseResult, err
+	}
+
+	return result.FloatingIP, responseResult, nil
+}
+
 // List gets a list of floating ips in the current domain.
 func List(ctx context.Context, client *selvpcclient.ServiceClient) ([]*FloatingIP, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")

--- a/selvpcclient/resell/v2/floatingips/schemas.go
+++ b/selvpcclient/resell/v2/floatingips/schemas.go
@@ -1,19 +1,31 @@
 package floatingips
 
+import "github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/servers"
+
 // FloatingIP represents a single Resell Floating IP.
 type FloatingIP struct {
 	// FloatingIPAddress represents IP address.
 	FloatingIPAddress string `json:"floating_ip_address"`
 
-	// ID is a unique id of the Floating IP.
+	// ID is a unique id of the floating ip.
 	ID string `json:"id"`
 
 	// ProjectID represents an associated Resell project.
 	ProjectID string `json:"project_id"`
 
-	// Region represents a region of where the Floating IP resides.
+	// PortID contains an uuid of the port to which floating ip is associated to.
+	PortID string `json:"port_id"`
+
+	// FixedIPAddress contains an IP address of the port to which floating ip is
+	// associated to.
+	FixedIPAddress string `json:"fixed_ip_address"`
+
+	// Region represents a region of where the floating ip resides.
 	Region string `json:"region"`
 
-	// Status represents a current status of the Floating IP.
+	// Status represents a current status of the floating ip.
 	Status string `json:"status"`
+
+	// Servers contains info about servers to which floating ip is associated to.
+	Servers []servers.Server `json:"servers"`
 }

--- a/selvpcclient/resell/v2/floatingips/testing/fixtures.go
+++ b/selvpcclient/resell/v2/floatingips/testing/fixtures.go
@@ -1,6 +1,55 @@
 package testing
 
-import "github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/floatingips"
+import (
+	"time"
+
+	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/floatingips"
+	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/servers"
+)
+
+// TestGetFloatingIPResponseRaw represents a raw response from the Get request.
+const TestGetFloatingIPResponseRaw = `
+{
+    "floatingip": {
+        "fixed_ip_address": "10.0.0.4",
+        "floating_ip_address": "203.0.113.11",
+        "id": "5232d5f3-4950-454b-bd41-78c5295622cd",
+        "port_id": "f7376dd2-c70f-4465-a5a8-e1a89b665d30",
+        "project_id": "49338ac045f448e294b25d013f890317",
+        "region": "ru-3",
+        "servers": [
+            {
+                "id": "253b680c-89f6-4c85-afbf-c9a67c92d3fe",
+                "name": "Node00",
+                "status": "ACTIVE",
+                "updated": "2018-02-20T22:02:21Z"
+            }
+        ],
+        "status": "ACTIVE"
+    }
+}
+`
+
+var floatingIPServerTimeStamp, _ = time.Parse(time.RFC3339, "2018-02-20T22:02:21Z")
+
+// TestGetFloatingIPResponse represents an unmarshalled TestGetFloatingIPResponseRaw.
+var TestGetFloatingIPResponse = &floatingips.FloatingIP{
+	FloatingIPAddress: "203.0.113.11",
+	ID:                "5232d5f3-4950-454b-bd41-78c5295622cd",
+	ProjectID:         "49338ac045f448e294b25d013f890317",
+	PortID:            "f7376dd2-c70f-4465-a5a8-e1a89b665d30",
+	FixedIPAddress:    "10.0.0.4",
+	Region:            "ru-3",
+	Status:            "ACTIVE",
+	Servers: []servers.Server{
+		{
+			ID:      "253b680c-89f6-4c85-afbf-c9a67c92d3fe",
+			Name:    "Node00",
+			Status:  "ACTIVE",
+			Updated: floatingIPServerTimeStamp,
+		},
+	},
+}
 
 // TestListFloatingIPsResponseRaw represents a raw response from the List request.
 const TestListFloatingIPsResponseRaw = `

--- a/selvpcclient/resell/v2/floatingips/testing/request_test.go
+++ b/selvpcclient/resell/v2/floatingips/testing/request_test.go
@@ -11,6 +11,32 @@ import (
 	"github.com/selectel/go-selvpcclient/selvpcclient/testutils"
 )
 
+func TestGetFloatingIP(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.NewTestResellV2Client()
+	testEnv.Mux.HandleFunc("/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, TestGetFloatingIPResponseRaw)
+
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected %s method but got %s", http.MethodGet, r.Method)
+		}
+	})
+
+	ctx := context.Background()
+	actual, _, err := floatingips.Get(ctx, testEnv.Client, "5232d5f3-4950-454b-bd41-78c5295622cd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := TestGetFloatingIPResponse
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("expected %#v, but got %#v", expected, actual)
+	}
+}
+
 func TestListFloatingIPs(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()

--- a/selvpcclient/resell/v2/servers/doc.go
+++ b/selvpcclient/resell/v2/servers/doc.go
@@ -1,0 +1,5 @@
+/*
+Package servers contains reusable structures for other go-selvpcclient packages.
+It doesn't provide any methods to work with actual VPC servers.
+*/
+package servers

--- a/selvpcclient/resell/v2/servers/schemas.go
+++ b/selvpcclient/resell/v2/servers/schemas.go
@@ -1,0 +1,22 @@
+package servers
+
+import (
+	"time"
+)
+
+// Server represents a simple server entity that is used by some other packages of
+// the go-selvpcclient.
+type Server struct {
+	// ID is a unique id of the server.
+	ID string `json:"id"`
+
+	// Name is a human-readable name of the server.
+	Name string `json:"name"`
+
+	// Status represents a current status of the server.
+	Status string `json:"status"`
+
+	// Updated contains ISO-8601 timestamps of when the state of the server
+	// last changed.
+	Updated time.Time `json:"updated"`
+}


### PR DESCRIPTION
Add GET method for the floating ip.
Add Server package that provides common structure for the floatingips
and subnets package.
Add doc example and test.

For #29 
