### PR TITLE
Add Resell V2 floating ip Delete method

### DIFF
--- a/selvpcclient/resell/v2/floatingips/doc.go
+++ b/selvpcclient/resell/v2/floatingips/doc.go
@@ -38,5 +38,12 @@ Example of creating floating ips in project
   for _, newFloatingIP := range newFloatingIPs {
     fmt.Printf("%v\n", newFloatingIP)
   }
+
+Example of deleting a single floatingip
+
+  _, err = floatingips.Delete(ctx, resellClient, "412a04ba-4cb2-4823-abd1-fcd48952b882")
+  if err != nil {
+    log.Fatal(err)
+  }
 */
 package floatingips

--- a/selvpcclient/resell/v2/floatingips/requests.go
+++ b/selvpcclient/resell/v2/floatingips/requests.go
@@ -85,3 +85,16 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, projectID s
 
 	return result.FloatingIPs, responseResult, nil
 }
+
+// Delete deletes a single floating ip by its id.
+func Delete(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*selvpcclient.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
+	responseResult, err := client.DoRequest(ctx, "DELETE", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if responseResult.Err != nil {
+		err = responseResult.Err
+	}
+	return responseResult, err
+}

--- a/selvpcclient/resell/v2/floatingips/testing/request_test.go
+++ b/selvpcclient/resell/v2/floatingips/testing/request_test.go
@@ -143,3 +143,22 @@ func TestCreateFloatingIPs(t *testing.T) {
 		t.Fatalf("expected %#v, but got %#v", actualResponse, expectedResponse)
 	}
 }
+
+func TestDeleteFloatingIP(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.NewTestResellV2Client()
+	testEnv.Mux.HandleFunc("/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+
+		if r.Method != http.MethodDelete {
+			t.Fatalf("expected %s method but got %s", http.MethodDelete, r.Method)
+		}
+	})
+
+	ctx := context.Background()
+	_, err := floatingips.Delete(ctx, testEnv.Client, "5232d5f3-4950-454b-bd41-78c5295622cd")
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Provide a way to delete a single floating ip, add test and doc example.

For #29 
