### PR TITLE
Resell V2 - add client with a custom endpoint

### DIFF
--- a/selvpcclient/resell/v2/client.go
+++ b/selvpcclient/resell/v2/client.go
@@ -11,11 +11,23 @@ import (
 const APIVersion = "v2"
 
 // NewV2ResellClient initializes a new Resell client for the V2 API.
-func NewV2ResellClient(TokenID string) *selvpcclient.ServiceClient {
+func NewV2ResellClient(tokenID string) *selvpcclient.ServiceClient {
 	resellClient := &selvpcclient.ServiceClient{
 		HTTPClient: &http.Client{},
 		Endpoint:   resell.Endpoint + "/" + APIVersion,
-		TokenID:    TokenID,
+		TokenID:    tokenID,
+		UserAgent:  resell.UserAgent,
+	}
+
+	return resellClient
+}
+
+// NewV2ResellClientWithEndpoint initializes a new Resell client for the V2 API with custom endpoint.
+func NewV2ResellClientWithEndpoint(tokenID, endpoint string) *selvpcclient.ServiceClient {
+	resellClient := &selvpcclient.ServiceClient{
+		HTTPClient: &http.Client{},
+		Endpoint:   endpoint,
+		TokenID:    tokenID,
 		UserAgent:  resell.UserAgent,
 	}
 

--- a/selvpcclient/resell/v2/client_test.go
+++ b/selvpcclient/resell/v2/client_test.go
@@ -1,0 +1,43 @@
+package v2
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/selectel/go-selvpcclient/selvpcclient"
+	"github.com/selectel/go-selvpcclient/selvpcclient/resell"
+)
+
+func TestNewV2ResellClient(t *testing.T) {
+	token := "fakeID"
+	expected := &selvpcclient.ServiceClient{
+		HTTPClient: &http.Client{},
+		Endpoint:   resell.Endpoint + "/" + APIVersion,
+		TokenID:    token,
+		UserAgent:  resell.UserAgent,
+	}
+
+	actual := NewV2ResellClient(token)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected %#v, but got %#v", expected, actual)
+	}
+}
+
+func TestNewV2ResellClientWithEndpoint(t *testing.T) {
+	token := "fakeID"
+	endpoint := "http://example.org"
+	expected := &selvpcclient.ServiceClient{
+		HTTPClient: &http.Client{},
+		Endpoint:   endpoint,
+		TokenID:    token,
+		UserAgent:  resell.UserAgent,
+	}
+
+	actual := NewV2ResellClientWithEndpoint(token, endpoint)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected %#v, but got %#v", expected, actual)
+	}
+}


### PR DESCRIPTION
Users may want to use custom endpoint for the Resell V2 API.
This commit adds a new NewV2ResellClientWithEndpoint method, fixes
argument capitalization in the old NewV2ResellClient method and adds
simple tests.

For #18 
