### PR TITLE
Resell V2 - add roles create method

### DIFF
--- a/selvpcclient/resell/v2/roles/doc.go
+++ b/selvpcclient/resell/v2/roles/doc.go
@@ -21,5 +21,17 @@ Example of getting roles for the specified user
   for _, myRole := range allRoles {
     fmt.Println(myRole)
   }
+
+Example of creating a single role
+
+  createOpts := roles.RoleOpt{
+    ProjectID: "49338ac045f448e294b25d013f890317",
+    UserID:    "763eecfaeb0c8e9b76ab12a82eb4c11",
+  }
+  role, _, err := roles.Create(ctx, resellClient, createOpts)
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Println(myRole)
 */
 package roles

--- a/selvpcclient/resell/v2/roles/requests.go
+++ b/selvpcclient/resell/v2/roles/requests.go
@@ -54,3 +54,26 @@ func ListUser(ctx context.Context, client *selvpcclient.ServiceClient, id string
 
 	return result.Roles, responseResult, nil
 }
+
+// Create requests a creation of the single role for the specified project and user.
+func Create(ctx context.Context, client *selvpcclient.ServiceClient, createOpts RoleOpt) (*Role, *selvpcclient.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, resourceURL, "projects", createOpts.ProjectID, "users", createOpts.UserID}, "/")
+	responseResult, err := client.DoRequest(ctx, "POST", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if responseResult.Err != nil {
+		return nil, responseResult, responseResult.Err
+	}
+
+	// Extract role from the response body.
+	var result struct {
+		Role *Role `json:"role"`
+	}
+	err = responseResult.ExtractResult(&result)
+	if err != nil {
+		return nil, responseResult, err
+	}
+
+	return result.Role, responseResult, nil
+}

--- a/selvpcclient/resell/v2/roles/requests_opts.go
+++ b/selvpcclient/resell/v2/roles/requests_opts.go
@@ -1,0 +1,10 @@
+package roles
+
+// RoleOpt represents options for a single Resell role.
+type RoleOpt struct {
+	// ProjectID represents needed Resell project.
+	ProjectID string `json:"project_id"`
+
+	// UserID represents needed Resell user.
+	UserID string `json:"user_id"`
+}

--- a/selvpcclient/resell/v2/roles/testing/fixtures.go
+++ b/selvpcclient/resell/v2/roles/testing/fixtures.go
@@ -62,6 +62,28 @@ const TestListUserResponseRaw = `
 }
 `
 
+// TestCreateRoleOpts represent options for the Create request.
+var TestCreateRoleOpts = roles.RoleOpt{
+	ProjectID: "49338ac045f448e294b25d013f890317",
+	UserID:    "763eecfaeb0c8e9b76ab12a82eb4c11",
+}
+
+// TestCreateRoleResponseRaw represents a raw response from the Create request.
+const TestCreateRoleResponseRaw = `
+{
+    "role": {
+        "project_id": "49338ac045f448e294b25d013f890317",
+        "user_id": "763eecfaeb0c8e9b76ab12a82eb4c11"
+    }
+}
+`
+
+// TestCreateRoleResponse represents the unmarshalled TestCreateRoleResponseRaw response.
+var TestCreateRoleResponse = &roles.Role{
+	ProjectID: "49338ac045f448e294b25d013f890317",
+	UserID:    "763eecfaeb0c8e9b76ab12a82eb4c11",
+}
+
 // TestManyRolesInvalidResponseRaw represents a raw invalid response with several roles.
 const TestManyRolesInvalidResponseRaw = `
 {
@@ -70,5 +92,14 @@ const TestManyRolesInvalidResponseRaw = `
             "project_id": 123
         }
     ]
+}
+`
+
+// TestSingleRoleInvalidResponseRaw represents a raw invalid response with a single role.
+const TestSingleRoleInvalidResponseRaw = `
+{
+    "role": {
+        "project_id": 123
+    }
 }
 `

--- a/selvpcclient/resell/v2/roles/testing/requests_test.go
+++ b/selvpcclient/resell/v2/roles/testing/requests_test.go
@@ -257,3 +257,114 @@ func TestListRolesUserUnmarshalError(t *testing.T) {
 		t.Fatal("expected error from the List method")
 	}
 }
+
+func TestCreateRole(t *testing.T) {
+	endpointCalled := false
+
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.NewTestResellV2Client()
+	testutils.HandleReqWithoutBody(testEnv.Mux,
+		"/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
+		TestCreateRoleResponseRaw, http.MethodPost, http.StatusOK, &endpointCalled, t)
+
+	ctx := context.Background()
+	createOpts := roles.RoleOpt{
+		ProjectID: "49338ac045f448e294b25d013f890317",
+		UserID:    "763eecfaeb0c8e9b76ab12a82eb4c11",
+	}
+	actual, _, err := roles.Create(ctx, testEnv.Client, createOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := TestCreateRoleResponse
+
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("expected %#v, but got %#v", expected, actual)
+	}
+}
+
+func TestCreateRoleHTTPError(t *testing.T) {
+	endpointCalled := false
+
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.NewTestResellV2Client()
+	testutils.HandleReqWithoutBody(testEnv.Mux,
+		"/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
+		TestCreateRoleResponseRaw, http.MethodPost, http.StatusBadGateway, &endpointCalled, t)
+
+	ctx := context.Background()
+	createOpts := roles.RoleOpt{
+		ProjectID: "49338ac045f448e294b25d013f890317",
+		UserID:    "763eecfaeb0c8e9b76ab12a82eb4c11",
+	}
+	role, httpResponse, err := roles.Create(ctx, testEnv.Client, createOpts)
+
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if role != nil {
+		t.Fatal("expected no role from the Create method")
+	}
+	if err == nil {
+		t.Fatal("expected error from the Create method")
+	}
+	if httpResponse.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected %d status in the HTTP response, but got %d",
+			http.StatusBadGateway, httpResponse.StatusCode)
+	}
+}
+
+func TestCreateRoleTimeoutError(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	testEnv.Server.Close()
+	defer testEnv.TearDownTestEnv()
+	testEnv.NewTestResellV2Client()
+
+	ctx := context.Background()
+	createOpts := roles.RoleOpt{
+		ProjectID: "49338ac045f448e294b25d013f890317",
+		UserID:    "763eecfaeb0c8e9b76ab12a82eb4c11",
+	}
+	role, _, err := roles.Create(ctx, testEnv.Client, createOpts)
+
+	if role != nil {
+		t.Fatal("expected no role from the Create method")
+	}
+	if err == nil {
+		t.Fatal("expected error from the Create method")
+	}
+}
+
+func TestCreateRoleUnmarshalError(t *testing.T) {
+	endpointCalled := false
+
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.NewTestResellV2Client()
+	testutils.HandleReqWithoutBody(testEnv.Mux,
+		"/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
+		TestSingleRoleInvalidResponseRaw, http.MethodPost, http.StatusOK, &endpointCalled, t)
+
+	ctx := context.Background()
+	createOpts := roles.RoleOpt{
+		ProjectID: "49338ac045f448e294b25d013f890317",
+		UserID:    "763eecfaeb0c8e9b76ab12a82eb4c11",
+	}
+	role, _, err := roles.Create(ctx, testEnv.Client, createOpts)
+
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if role != nil {
+		t.Fatal("expected no role from the Create method")
+	}
+	if err == nil {
+		t.Fatal("expected error from the Create method")
+	}
+}


### PR DESCRIPTION
Add method to create a single Resell role.
Add tests and doc example.

For #28 
