### PR TITLE
Move some hardcoded values to separated constants

### DIFF
--- a/selvpcclient/resell/resell.go
+++ b/selvpcclient/resell/resell.go
@@ -3,8 +3,12 @@ package resell
 import "github.com/selectel/go-selvpcclient/selvpcclient"
 
 const (
+	// ServiceType contains the name of the Selectel VPC service for which this
+	// package is intended.
+	ServiceType = "resell"
+
 	// Endpoint contains the base url for all versions of the Resell client.
-	Endpoint = selvpcclient.DefaultEndpoint + "/resell"
+	Endpoint = selvpcclient.DefaultEndpoint + "/" + ServiceType
 
 	// UserAgent contains the user agent for all versions of the Resell client.
 	UserAgent = selvpcclient.DefaultUserAgent

--- a/selvpcclient/selvpc.go
+++ b/selvpcclient/selvpc.go
@@ -15,11 +15,14 @@ const (
 	// AppVersion is a version of the application.
 	AppVersion = "1.0.0"
 
+	// AppName is a global application name.
+	AppName = "selvpcclient"
+
 	// DefaultEndpoint contains basic endpoint for queries.
 	DefaultEndpoint = "https://api.selectel.ru/vpc"
 
 	// DefaultUserAgent contains basic user agent that will be used in queries.
-	DefaultUserAgent = "selvpcclient/" + AppVersion
+	DefaultUserAgent = AppName + "/" + AppVersion
 )
 
 // ServiceClient stores details that are needed to work with different Selectel VPC APIs.


### PR DESCRIPTION
This commit moves the application name and resell service type to
separate constants so they can be reused.
