### PR TITLE
Licenses: add query parameters to the List method

### DIFF
--- a/selvpcclient/resell/v2/licenses/requests.go
+++ b/selvpcclient/resell/v2/licenses/requests.go
@@ -35,8 +35,17 @@ func Get(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*L
 }
 
 // List gets a list of licenses in the current domain.
-func List(ctx context.Context, client *selvpcclient.ServiceClient) ([]*License, *selvpcclient.ResponseResult, error) {
+func List(ctx context.Context, client *selvpcclient.ServiceClient, opts ListOpts) ([]*License, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
+
+	queryParams, err := selvpcclient.BuildQueryParameters(opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	if queryParams != "" {
+		url = strings.Join([]string{url, queryParams}, "?")
+	}
+
 	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err

--- a/selvpcclient/resell/v2/licenses/requests_opts.go
+++ b/selvpcclient/resell/v2/licenses/requests_opts.go
@@ -17,3 +17,8 @@ type LicenseOpt struct {
 	// Type represents needed type of the license.
 	Type string `json:"type"`
 }
+
+// ListOpts represents options for the licenses List request.
+type ListOpts struct {
+	Detailed bool `param:"detailed"`
+}

--- a/selvpcclient/resell/v2/licenses/testing/requests_test.go
+++ b/selvpcclient/resell/v2/licenses/testing/requests_test.go
@@ -114,7 +114,7 @@ func TestListLicenses(t *testing.T) {
 		TestListLicensesResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
 
 	ctx := context.Background()
-	actual, _, err := licenses.List(ctx, testEnv.Client)
+	actual, _, err := licenses.List(ctx, testEnv.Client, licenses.ListOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestListLicensesSingle(t *testing.T) {
 		TestListLicensesSingleResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
 
 	ctx := context.Background()
-	actual, _, err := licenses.List(ctx, testEnv.Client)
+	actual, _, err := licenses.List(ctx, testEnv.Client, licenses.ListOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestListLicensesHTTPError(t *testing.T) {
 		&endpointCalled, t)
 
 	ctx := context.Background()
-	allLicenses, httpResponse, err := licenses.List(ctx, testEnv.Client)
+	allLicenses, httpResponse, err := licenses.List(ctx, testEnv.Client, licenses.ListOpts{})
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
@@ -194,7 +194,7 @@ func TestListLicensesTimeoutError(t *testing.T) {
 	testEnv.NewTestResellV2Client()
 
 	ctx := context.Background()
-	allLicenses, _, err := licenses.List(ctx, testEnv.Client)
+	allLicenses, _, err := licenses.List(ctx, testEnv.Client, licenses.ListOpts{})
 
 	if allLicenses != nil {
 		t.Fatal("expected no licenses from the List method")
@@ -215,7 +215,7 @@ func TestListLicensesUnmarshalError(t *testing.T) {
 		&endpointCalled, t)
 
 	ctx := context.Background()
-	allLicenses, _, err := licenses.List(ctx, testEnv.Client)
+	allLicenses, _, err := licenses.List(ctx, testEnv.Client, licenses.ListOpts{})
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")


### PR DESCRIPTION
Allow to get detailed list of licenses.

For #73