### PR TITLE
FloatingIPs: add query params to the List method

### DIFF
--- a/selvpcclient/resell/v2/floatingips/requests.go
+++ b/selvpcclient/resell/v2/floatingips/requests.go
@@ -35,8 +35,17 @@ func Get(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*F
 }
 
 // List gets a list of floating ips in the current domain.
-func List(ctx context.Context, client *selvpcclient.ServiceClient) ([]*FloatingIP, *selvpcclient.ResponseResult, error) {
+func List(ctx context.Context, client *selvpcclient.ServiceClient, opts ListOpts) ([]*FloatingIP, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
+
+	queryParams, err := selvpcclient.BuildQueryParameters(opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	if queryParams != "" {
+		url = strings.Join([]string{url, queryParams}, "?")
+	}
+
 	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err

--- a/selvpcclient/resell/v2/floatingips/requests_opts.go
+++ b/selvpcclient/resell/v2/floatingips/requests_opts.go
@@ -14,3 +14,8 @@ type FloatingIPOpt struct {
 	// Quantity represents how many floating ips do we need to create in a single request.
 	Quantity int `json:"quantity"`
 }
+
+// ListOpts represents options for the floating ips List request.
+type ListOpts struct {
+	Detailed bool `param:"detailed"`
+}

--- a/selvpcclient/resell/v2/floatingips/testing/requests_test.go
+++ b/selvpcclient/resell/v2/floatingips/testing/requests_test.go
@@ -114,7 +114,7 @@ func TestListFloatingIPs(t *testing.T) {
 		TestListFloatingIPsResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
 
 	ctx := context.Background()
-	actual, _, err := floatingips.List(ctx, testEnv.Client)
+	actual, _, err := floatingips.List(ctx, testEnv.Client, floatingips.ListOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestListFloatingIPsSingle(t *testing.T) {
 		TestListFloatingIPsSingleResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
 
 	ctx := context.Background()
-	actual, _, err := floatingips.List(ctx, testEnv.Client)
+	actual, _, err := floatingips.List(ctx, testEnv.Client, floatingips.ListOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestListFloatingIPsHTTPError(t *testing.T) {
 		&endpointCalled, t)
 
 	ctx := context.Background()
-	allFloatingIPs, httpResponse, err := floatingips.List(ctx, testEnv.Client)
+	allFloatingIPs, httpResponse, err := floatingips.List(ctx, testEnv.Client, floatingips.ListOpts{})
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
@@ -194,7 +194,7 @@ func TestListFloatingIPsTimeoutError(t *testing.T) {
 	testEnv.NewTestResellV2Client()
 
 	ctx := context.Background()
-	allFloatingIPs, _, err := floatingips.List(ctx, testEnv.Client)
+	allFloatingIPs, _, err := floatingips.List(ctx, testEnv.Client, floatingips.ListOpts{})
 
 	if allFloatingIPs != nil {
 		t.Fatal("expected no floating ips from the List method")
@@ -215,7 +215,7 @@ func TestListFloatingIPsUnmarshalError(t *testing.T) {
 		&endpointCalled, t)
 
 	ctx := context.Background()
-	allFloatingIPs, _, err := floatingips.List(ctx, testEnv.Client)
+	allFloatingIPs, _, err := floatingips.List(ctx, testEnv.Client, floatingips.ListOpts{})
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")


### PR DESCRIPTION
Allow to get detailed list of floating IPs, update unit tests.

For #73 
