### PR TITLE
Subnets: add query params to the List method

### DIFF
--- a/selvpcclient/resell/v2/subnets/requests.go
+++ b/selvpcclient/resell/v2/subnets/requests.go
@@ -35,8 +35,17 @@ func Get(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*S
 }
 
 // List gets a list of subnets in the current domain.
-func List(ctx context.Context, client *selvpcclient.ServiceClient) ([]*Subnet, *selvpcclient.ResponseResult, error) {
+func List(ctx context.Context, client *selvpcclient.ServiceClient, opts ListOpts) ([]*Subnet, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
+
+	queryParams, err := selvpcclient.BuildQueryParameters(opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	if queryParams != "" {
+		url = strings.Join([]string{url, queryParams}, "?")
+	}
+
 	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, nil, err

--- a/selvpcclient/resell/v2/subnets/requests_opts.go
+++ b/selvpcclient/resell/v2/subnets/requests_opts.go
@@ -22,3 +22,8 @@ type SubnetOpt struct {
 	// PrefixLength represents length of the subnet prefix.
 	PrefixLength int `json:"prefix_length"`
 }
+
+// ListOpts represents options for the licenses List request.
+type ListOpts struct {
+	Detailed bool `param:"detailed"`
+}

--- a/selvpcclient/resell/v2/subnets/testing/requests_test.go
+++ b/selvpcclient/resell/v2/subnets/testing/requests_test.go
@@ -114,7 +114,7 @@ func TestListSubnets(t *testing.T) {
 		TestListSubnetsResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
 
 	ctx := context.Background()
-	actual, _, err := subnets.List(ctx, testEnv.Client)
+	actual, _, err := subnets.List(ctx, testEnv.Client, subnets.ListOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestListSubnetsSingle(t *testing.T) {
 		TestListSubnetsSingleResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
 
 	ctx := context.Background()
-	actual, _, err := subnets.List(ctx, testEnv.Client)
+	actual, _, err := subnets.List(ctx, testEnv.Client, subnets.ListOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestListSubnetsHTTPError(t *testing.T) {
 		&endpointCalled, t)
 
 	ctx := context.Background()
-	allSubnet, httpResponse, err := subnets.List(ctx, testEnv.Client)
+	allSubnet, httpResponse, err := subnets.List(ctx, testEnv.Client, subnets.ListOpts{})
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
@@ -194,7 +194,7 @@ func TestListSubnetsTimeoutError(t *testing.T) {
 	testEnv.NewTestResellV2Client()
 
 	ctx := context.Background()
-	allSubnet, _, err := subnets.List(ctx, testEnv.Client)
+	allSubnet, _, err := subnets.List(ctx, testEnv.Client, subnets.ListOpts{})
 
 	if allSubnet != nil {
 		t.Fatal("expected no subnets from the List method")
@@ -215,7 +215,7 @@ func TestListSubnetsUnmarshalError(t *testing.T) {
 		&endpointCalled, t)
 
 	ctx := context.Background()
-	allSubnet, _, err := subnets.List(ctx, testEnv.Client)
+	allSubnet, _, err := subnets.List(ctx, testEnv.Client, subnets.ListOpts{})
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")


### PR DESCRIPTION
Allow to get detailed list of subnets, update unit tests.

For #73 
