### PR TITLE
Refactor hardcoded methods, emptyFmt and testutils

### DIFF
--- a/selvpcclient/resell/v2/capabilities/requests.go
+++ b/selvpcclient/resell/v2/capabilities/requests.go
@@ -2,6 +2,7 @@ package capabilities
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"github.com/selectel/go-selvpcclient/selvpcclient"
@@ -12,7 +13,7 @@ const resourceURL = "capabilities"
 // Get returns the domain capabilities.
 func Get(ctx context.Context, client *selvpcclient.ServiceClient) (*Capabilities, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/selvpcclient/resell/v2/capabilities/testing/requests_test.go
+++ b/selvpcclient/resell/v2/capabilities/testing/requests_test.go
@@ -25,7 +25,7 @@ func TestGetCapabilities(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	capabilities, _, err := capabilities.Get(ctx, testEnv.Client)
+	c, _, err := capabilities.Get(ctx, testEnv.Client)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,23 +33,23 @@ func TestGetCapabilities(t *testing.T) {
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
 	}
-	if capabilities == nil {
+	if c == nil {
 		t.Fatal("didn't get capabilities")
 	}
-	if len(capabilities.Licenses) != 2 {
-		t.Errorf("expected 2 licenses, but got %d", len(capabilities.Licenses))
+	if len(c.Licenses) != 2 {
+		t.Errorf("expected 2 licenses, but got %d", len(c.Licenses))
 	}
-	if len(capabilities.Regions) != 3 {
-		t.Errorf("expected 3 regions, but got %d", len(capabilities.Regions))
+	if len(c.Regions) != 3 {
+		t.Errorf("expected 3 regions, but got %d", len(c.Regions))
 	}
-	if len(capabilities.Resources) != 16 {
-		t.Errorf("expected 16 resources, but got %d", len(capabilities.Resources))
+	if len(c.Resources) != 16 {
+		t.Errorf("expected 16 resources, but got %d", len(c.Resources))
 	}
-	if len(capabilities.Subnets) != 1 {
-		t.Errorf("expected 1 subnets, but got %d", len(capabilities.Subnets))
+	if len(c.Subnets) != 1 {
+		t.Errorf("expected 1 subnets, but got %d", len(c.Subnets))
 	}
-	if len(capabilities.Traffic.Granularities) != 3 {
-		t.Errorf("expected 3 traffic granularities, but got %d", len(capabilities.Traffic.Granularities))
+	if len(c.Traffic.Granularities) != 3 {
+		t.Errorf("expected 3 traffic granularities, but got %d", len(c.Traffic.Granularities))
 	}
 }
 
@@ -69,12 +69,12 @@ func TestGetCapabilitiesHTTPError(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	capabilities, httpResponse, err := capabilities.Get(ctx, testEnv.Client)
+	c, httpResponse, err := capabilities.Get(ctx, testEnv.Client)
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
 	}
-	if capabilities != nil {
+	if c != nil {
 		t.Fatal("expected no capabilities from the Get method")
 	}
 	if err == nil {
@@ -93,9 +93,9 @@ func TestGetCapabilitiesTimeoutError(t *testing.T) {
 	testEnv.NewTestResellV2Client()
 
 	ctx := context.Background()
-	capabilities, _, err := capabilities.Get(ctx, testEnv.Client)
+	c, _, err := capabilities.Get(ctx, testEnv.Client)
 
-	if capabilities != nil {
+	if c != nil {
 		t.Fatal("expected no capabilities from the Get method")
 	}
 	if err == nil {
@@ -119,12 +119,12 @@ func TestGetCapabilitiesUnmarshalError(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	capabilities, _, err := capabilities.Get(ctx, testEnv.Client)
+	c, _, err := capabilities.Get(ctx, testEnv.Client)
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
 	}
-	if capabilities != nil {
+	if c != nil {
 		t.Fatal("expected no capabilities from the Get method")
 	}
 	if err == nil {

--- a/selvpcclient/resell/v2/capabilities/testing/requests_test.go
+++ b/selvpcclient/resell/v2/capabilities/testing/requests_test.go
@@ -114,7 +114,7 @@ func TestGetCapabilitiesUnmarshalError(t *testing.T) {
 		URL:         "/resell/v2/capabilities",
 		RawResponse: TestGetCapabilitiesInvalidRaw,
 		Method:      http.MethodGet,
-		Status:      http.StatusBadGateway,
+		Status:      http.StatusOK,
 		CallFlag:    &endpointCalled,
 	})
 

--- a/selvpcclient/resell/v2/capabilities/testing/requests_test.go
+++ b/selvpcclient/resell/v2/capabilities/testing/requests_test.go
@@ -15,8 +15,14 @@ func TestGetCapabilities(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/capabilities",
-		TestGetCapabilitiesRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/capabilities",
+		RawResponse: TestGetCapabilitiesRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	capabilities, _, err := capabilities.Get(ctx, testEnv.Client)
@@ -53,8 +59,14 @@ func TestGetCapabilitiesHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/capabilities",
-		TestGetCapabilitiesRaw, http.MethodGet, http.StatusBadGateway, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/capabilities",
+		RawResponse: TestGetCapabilitiesRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	capabilities, httpResponse, err := capabilities.Get(ctx, testEnv.Client)
@@ -97,8 +109,14 @@ func TestGetCapabilitiesUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/capabilities",
-		TestGetCapabilitiesInvalidRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/capabilities",
+		RawResponse: TestGetCapabilitiesInvalidRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	capabilities, _, err := capabilities.Get(ctx, testEnv.Client)

--- a/selvpcclient/resell/v2/capabilities/testing/requests_test.go
+++ b/selvpcclient/resell/v2/capabilities/testing/requests_test.go
@@ -15,7 +15,7 @@ func TestGetCapabilities(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/capabilities",
 		RawResponse: TestGetCapabilitiesRaw,
@@ -59,7 +59,7 @@ func TestGetCapabilitiesHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/capabilities",
 		RawResponse: TestGetCapabilitiesRaw,
@@ -109,7 +109,7 @@ func TestGetCapabilitiesUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/capabilities",
 		RawResponse: TestGetCapabilitiesInvalidRaw,

--- a/selvpcclient/resell/v2/floatingips/requests.go
+++ b/selvpcclient/resell/v2/floatingips/requests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/selectel/go-selvpcclient/selvpcclient"
@@ -14,7 +15,7 @@ const resourceURL = "floatingips"
 // Get returns a single floating ip by its id.
 func Get(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*FloatingIP, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -46,7 +47,7 @@ func List(ctx context.Context, client *selvpcclient.ServiceClient, opts ListOpts
 		url = strings.Join([]string{url, queryParams}, "?")
 	}
 
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,7 +76,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, projectID s
 	}
 
 	url := strings.Join([]string{client.Endpoint, resourceURL, "projects", projectID}, "/")
-	responseResult, err := client.DoRequest(ctx, "POST", url, bytes.NewReader(requestBody))
+	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -98,7 +99,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, projectID s
 // Delete deletes a single floating ip by its id.
 func Delete(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "DELETE", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/selvpcclient/resell/v2/floatingips/testing/requests_test.go
+++ b/selvpcclient/resell/v2/floatingips/testing/requests_test.go
@@ -16,7 +16,7 @@ func TestGetFloatingIP(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
 		RawResponse: TestGetFloatingIPResponseRaw,
@@ -47,7 +47,7 @@ func TestGetFloatingIPHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
 		RawResponse: TestGetFloatingIPResponseRaw,
@@ -97,7 +97,7 @@ func TestGetFloatingIPUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
 		RawResponse: TestSingleFloatingIPInvalidResponseRaw,
@@ -126,7 +126,7 @@ func TestListFloatingIPs(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/floatingips",
 		RawResponse: TestListFloatingIPsResponseRaw,
@@ -162,7 +162,7 @@ func TestListFloatingIPsSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/floatingips",
 		RawResponse: TestListFloatingIPsSingleResponseRaw,
@@ -193,7 +193,7 @@ func TestListFloatingIPsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/floatingips",
 		RawResponse: TestListFloatingIPsResponseRaw,
@@ -243,7 +243,7 @@ func TestListFloatingIPsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/floatingips",
 		RawResponse: TestManyFloatingIPsInvalidResponseRaw,
@@ -272,7 +272,7 @@ func TestCreateFloatingIPs(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/floatingips/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestCreateFloatingIPResponseRaw,
@@ -305,7 +305,7 @@ func TestCreateFloatingIPsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/floatingips/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestCreateFloatingIPResponseRaw,
@@ -358,7 +358,7 @@ func TestCreateFloatingIPsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/floatingips/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestManyFloatingIPsInvalidResponseRaw,
@@ -389,7 +389,7 @@ func TestDeleteFloatingIP(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
 		Method:   http.MethodDelete,
@@ -413,7 +413,7 @@ func TestDeleteFloatingIPHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
 		Method:   http.MethodDelete,

--- a/selvpcclient/resell/v2/floatingips/testing/requests_test.go
+++ b/selvpcclient/resell/v2/floatingips/testing/requests_test.go
@@ -16,8 +16,14 @@ func TestGetFloatingIP(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
-		TestGetFloatingIPResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
+		RawResponse: TestGetFloatingIPResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := floatingips.Get(ctx, testEnv.Client, "5232d5f3-4950-454b-bd41-78c5295622cd")
@@ -41,9 +47,14 @@ func TestGetFloatingIPHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
-		TestGetFloatingIPResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
+		RawResponse: TestGetFloatingIPResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	floatingIP, httpResponse, err := floatingips.Get(ctx, testEnv.Client, "5232d5f3-4950-454b-bd41-78c5295622cd")
@@ -86,9 +97,14 @@ func TestGetFloatingIPUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
-		TestSingleFloatingIPInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
+		RawResponse: TestSingleFloatingIPInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	floatingIP, _, err := floatingips.Get(ctx, testEnv.Client, "5232d5f3-4950-454b-bd41-78c5295622cd")
@@ -110,8 +126,14 @@ func TestListFloatingIPs(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/floatingips",
-		TestListFloatingIPsResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/floatingips",
+		RawResponse: TestListFloatingIPsResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := floatingips.List(ctx, testEnv.Client, floatingips.ListOpts{})
@@ -140,8 +162,14 @@ func TestListFloatingIPsSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/floatingips",
-		TestListFloatingIPsSingleResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/floatingips",
+		RawResponse: TestListFloatingIPsSingleResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := floatingips.List(ctx, testEnv.Client, floatingips.ListOpts{})
@@ -165,9 +193,14 @@ func TestListFloatingIPsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/floatingips",
-		TestListFloatingIPsResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/floatingips",
+		RawResponse: TestListFloatingIPsResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allFloatingIPs, httpResponse, err := floatingips.List(ctx, testEnv.Client, floatingips.ListOpts{})
@@ -210,9 +243,14 @@ func TestListFloatingIPsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/floatingips",
-		TestManyFloatingIPsInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/floatingips",
+		RawResponse: TestManyFloatingIPsInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allFloatingIPs, _, err := floatingips.List(ctx, testEnv.Client, floatingips.ListOpts{})
@@ -234,9 +272,15 @@ func TestCreateFloatingIPs(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/floatingips/projects/49338ac045f448e294b25d013f890317",
-		TestCreateFloatingIPResponseRaw, TestCreateFloatingIPOptsRaw, http.MethodPost, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/floatingips/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestCreateFloatingIPResponseRaw,
+		RawRequest:  TestCreateFloatingIPOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateFloatingIPOpts
@@ -261,9 +305,15 @@ func TestCreateFloatingIPsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/floatingips/projects/49338ac045f448e294b25d013f890317",
-		TestCreateFloatingIPResponseRaw, TestCreateFloatingIPOptsRaw, http.MethodPost,
-		http.StatusBadRequest, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/floatingips/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestCreateFloatingIPResponseRaw,
+		RawRequest:  TestCreateFloatingIPOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusBadRequest,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateFloatingIPOpts
@@ -308,8 +358,15 @@ func TestCreateFloatingIPsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/floatingips/projects/49338ac045f448e294b25d013f890317",
-		TestManyFloatingIPsInvalidResponseRaw, TestCreateFloatingIPOptsRaw, http.MethodPost, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/floatingips/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestManyFloatingIPsInvalidResponseRaw,
+		RawRequest:  TestCreateFloatingIPOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateFloatingIPOpts
@@ -332,8 +389,13 @@ func TestDeleteFloatingIP(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
-		"", http.MethodDelete, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
+		Method:   http.MethodDelete,
+		Status:   http.StatusOK,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	_, err := floatingips.Delete(ctx, testEnv.Client, "5232d5f3-4950-454b-bd41-78c5295622cd")
@@ -351,8 +413,13 @@ func TestDeleteFloatingIPHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
-		"", http.MethodDelete, http.StatusBadGateway, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/floatingips/5232d5f3-4950-454b-bd41-78c5295622cd",
+		Method:   http.MethodDelete,
+		Status:   http.StatusBadGateway,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	httpResponse, err := floatingips.Delete(ctx, testEnv.Client, "5232d5f3-4950-454b-bd41-78c5295622cd")

--- a/selvpcclient/resell/v2/licenses/requests.go
+++ b/selvpcclient/resell/v2/licenses/requests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/selectel/go-selvpcclient/selvpcclient"
@@ -14,7 +15,7 @@ const resourceURL = "licenses"
 // Get returns a single license by its id.
 func Get(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*License, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -46,7 +47,7 @@ func List(ctx context.Context, client *selvpcclient.ServiceClient, opts ListOpts
 		url = strings.Join([]string{url, queryParams}, "?")
 	}
 
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,7 +76,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, projectID s
 	}
 
 	url := strings.Join([]string{client.Endpoint, resourceURL, "projects", projectID}, "/")
-	responseResult, err := client.DoRequest(ctx, "POST", url, bytes.NewReader(requestBody))
+	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -98,7 +99,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, projectID s
 // Delete deletes a single license by its id.
 func Delete(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "DELETE", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/selvpcclient/resell/v2/licenses/testing/requests_test.go
+++ b/selvpcclient/resell/v2/licenses/testing/requests_test.go
@@ -16,8 +16,14 @@ func TestGetLicense(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/licenses/123123",
-		TestGetLicenseResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/licenses/123123",
+		RawResponse: TestGetLicenseResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := licenses.Get(ctx, testEnv.Client, "123123")
@@ -41,9 +47,14 @@ func TestGetLicenseHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/licenses/123123",
-		TestGetLicenseResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/licenses/123123",
+		RawResponse: TestGetLicenseResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	license, httpResponse, err := licenses.Get(ctx, testEnv.Client, "123123")
@@ -86,9 +97,14 @@ func TestGetLicenseUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/licenses/123123",
-		TestSingleLicenseInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/licenses/123123",
+		RawResponse: TestSingleLicenseInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	license, _, err := licenses.Get(ctx, testEnv.Client, "123123")
@@ -110,8 +126,14 @@ func TestListLicenses(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/licenses",
-		TestListLicensesResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/licenses",
+		RawResponse: TestListLicensesResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := licenses.List(ctx, testEnv.Client, licenses.ListOpts{})
@@ -140,8 +162,14 @@ func TestListLicensesSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/licenses",
-		TestListLicensesSingleResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/licenses",
+		RawResponse: TestListLicensesSingleResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := licenses.List(ctx, testEnv.Client, licenses.ListOpts{})
@@ -165,9 +193,14 @@ func TestListLicensesHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/licenses",
-		TestListLicensesResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/licenses",
+		RawResponse: TestListLicensesResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allLicenses, httpResponse, err := licenses.List(ctx, testEnv.Client, licenses.ListOpts{})
@@ -210,9 +243,14 @@ func TestListLicensesUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/licenses",
-		TestManyLicensesInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/licenses",
+		RawResponse: TestManyLicensesInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allLicenses, _, err := licenses.List(ctx, testEnv.Client, licenses.ListOpts{})
@@ -234,9 +272,15 @@ func TestCreateLicenses(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/licenses/projects/49338ac045f448e294b25d013f890317",
-		TestCreateLicenseResponseRaw, TestCreateLicenseOptsRaw, http.MethodPost, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/licenses/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestCreateLicenseResponseRaw,
+		RawRequest:  TestCreateLicenseOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateLicenseOpts
@@ -261,9 +305,15 @@ func TestCreateLicensesHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/licenses/projects/49338ac045f448e294b25d013f890317",
-		TestCreateLicenseResponseRaw, TestCreateLicenseOptsRaw, http.MethodPost,
-		http.StatusBadRequest, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/licenses/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestCreateLicenseResponseRaw,
+		RawRequest:  TestCreateLicenseOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusBadRequest,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateLicenseOpts
@@ -308,8 +358,15 @@ func TestCreateLicensesUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/licenses/projects/49338ac045f448e294b25d013f890317",
-		TestManyLicensesInvalidResponseRaw, TestCreateLicenseOptsRaw, http.MethodPost, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/licenses/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestManyLicensesInvalidResponseRaw,
+		RawRequest:  TestCreateLicenseOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateLicenseOpts
@@ -332,8 +389,13 @@ func TestDeleteLicense(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/licenses/5232d5f3-4950-454b-bd41-78c5295622cd",
-		"", http.MethodDelete, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/licenses/5232d5f3-4950-454b-bd41-78c5295622cd",
+		Method:   http.MethodDelete,
+		Status:   http.StatusOK,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	_, err := licenses.Delete(ctx, testEnv.Client, "5232d5f3-4950-454b-bd41-78c5295622cd")
@@ -351,8 +413,13 @@ func TestDeleteLicenseHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/licenses/5232d5f3-4950-454b-bd41-78c5295622cd",
-		"", http.MethodDelete, http.StatusBadGateway, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/licenses/5232d5f3-4950-454b-bd41-78c5295622cd",
+		Method:   http.MethodDelete,
+		Status:   http.StatusBadGateway,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	httpResponse, err := licenses.Delete(ctx, testEnv.Client, "5232d5f3-4950-454b-bd41-78c5295622cd")

--- a/selvpcclient/resell/v2/licenses/testing/requests_test.go
+++ b/selvpcclient/resell/v2/licenses/testing/requests_test.go
@@ -16,7 +16,7 @@ func TestGetLicense(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/licenses/123123",
 		RawResponse: TestGetLicenseResponseRaw,
@@ -47,7 +47,7 @@ func TestGetLicenseHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/licenses/123123",
 		RawResponse: TestGetLicenseResponseRaw,
@@ -97,7 +97,7 @@ func TestGetLicenseUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/licenses/123123",
 		RawResponse: TestSingleLicenseInvalidResponseRaw,
@@ -126,7 +126,7 @@ func TestListLicenses(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/licenses",
 		RawResponse: TestListLicensesResponseRaw,
@@ -162,7 +162,7 @@ func TestListLicensesSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/licenses",
 		RawResponse: TestListLicensesSingleResponseRaw,
@@ -193,7 +193,7 @@ func TestListLicensesHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/licenses",
 		RawResponse: TestListLicensesResponseRaw,
@@ -243,7 +243,7 @@ func TestListLicensesUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/licenses",
 		RawResponse: TestManyLicensesInvalidResponseRaw,
@@ -272,7 +272,7 @@ func TestCreateLicenses(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/licenses/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestCreateLicenseResponseRaw,
@@ -305,7 +305,7 @@ func TestCreateLicensesHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/licenses/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestCreateLicenseResponseRaw,
@@ -358,7 +358,7 @@ func TestCreateLicensesUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/licenses/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestManyLicensesInvalidResponseRaw,
@@ -389,7 +389,7 @@ func TestDeleteLicense(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/licenses/5232d5f3-4950-454b-bd41-78c5295622cd",
 		Method:   http.MethodDelete,
@@ -413,7 +413,7 @@ func TestDeleteLicenseHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/licenses/5232d5f3-4950-454b-bd41-78c5295622cd",
 		Method:   http.MethodDelete,

--- a/selvpcclient/resell/v2/licenses/testing/requests_test.go
+++ b/selvpcclient/resell/v2/licenses/testing/requests_test.go
@@ -317,12 +317,12 @@ func TestCreateLicensesHTTPError(t *testing.T) {
 
 	ctx := context.Background()
 	createOpts := TestCreateLicenseOpts
-	licenses, httpResponse, err := licenses.Create(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317", createOpts)
+	l, httpResponse, err := licenses.Create(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317", createOpts)
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
 	}
-	if licenses != nil {
+	if l != nil {
 		t.Fatal("expected no licenses from the Create method")
 	}
 	if err == nil {
@@ -342,9 +342,9 @@ func TestCreateLicensesTimeoutError(t *testing.T) {
 
 	ctx := context.Background()
 	createOpts := TestCreateLicenseOpts
-	licenses, _, err := licenses.Create(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317", createOpts)
+	l, _, err := licenses.Create(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317", createOpts)
 
-	if licenses != nil {
+	if l != nil {
 		t.Fatal("expected no licenses from the Create method")
 	}
 	if err == nil {
@@ -370,12 +370,12 @@ func TestCreateLicensesUnmarshalError(t *testing.T) {
 
 	ctx := context.Background()
 	createOpts := TestCreateLicenseOpts
-	licenses, _, err := licenses.Create(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317", createOpts)
+	l, _, err := licenses.Create(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317", createOpts)
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
 	}
-	if licenses != nil {
+	if l != nil {
 		t.Fatal("expected no licenses from the Create method")
 	}
 	if err == nil {

--- a/selvpcclient/resell/v2/projects/requests.go
+++ b/selvpcclient/resell/v2/projects/requests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/selectel/go-selvpcclient/selvpcclient"
@@ -14,7 +15,7 @@ const resourceURL = "projects"
 // Get returns a single project by its id.
 func Get(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*Project, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -37,7 +38,7 @@ func Get(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*P
 // List gets a list of projects in the current domain.
 func List(ctx context.Context, client *selvpcclient.ServiceClient) ([]*Project, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -70,7 +71,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, createOpts 
 	}
 
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
-	responseResult, err := client.DoRequest(ctx, "POST", url, bytes.NewReader(requestBody))
+	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -103,7 +104,7 @@ func Update(ctx context.Context, client *selvpcclient.ServiceClient, id string, 
 	}
 
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "PATCH", url, bytes.NewReader(requestBody))
+	responseResult, err := client.DoRequest(ctx, http.MethodPatch, url, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,7 +127,7 @@ func Update(ctx context.Context, client *selvpcclient.ServiceClient, id string, 
 // Delete deletes a single project by its id.
 func Delete(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "DELETE", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/selvpcclient/resell/v2/projects/testing/requests_test.go
+++ b/selvpcclient/resell/v2/projects/testing/requests_test.go
@@ -134,7 +134,7 @@ func TestGetProjectUnmarshalError(t *testing.T) {
 		URL:         "/resell/v2/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestSingleProjectInvalidResponseRaw,
 		Method:      http.MethodGet,
-		Status:      http.StatusBadGateway,
+		Status:      http.StatusOK,
 		CallFlag:    &endpointCalled,
 	})
 

--- a/selvpcclient/resell/v2/projects/testing/requests_test.go
+++ b/selvpcclient/resell/v2/projects/testing/requests_test.go
@@ -16,7 +16,7 @@ func TestGetProject(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestGetProjectResponseRaw,
@@ -48,7 +48,7 @@ func TestGetProjectSingleQuota(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestGetProjectResponseSingleQuotaRaw,
@@ -79,7 +79,7 @@ func TestGetProjectHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestGetProjectResponseRaw,
@@ -129,7 +129,7 @@ func TestGetProjectUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestSingleProjectInvalidResponseRaw,
@@ -158,7 +158,7 @@ func TestListProjects(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects",
 		RawResponse: TestListProjectsResponseRaw,
@@ -190,7 +190,7 @@ func TestListProjectsSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects",
 		RawResponse: TestListProjectsResponseSingleRaw,
@@ -221,7 +221,7 @@ func TestListProjectsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects",
 		RawResponse: TestListProjectsResponseRaw,
@@ -271,7 +271,7 @@ func TestListProjectsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects",
 		RawResponse: TestManyProjectsInvalidResponseRaw,
@@ -300,7 +300,7 @@ func TestCreateProject(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects",
 		RawResponse: TestCreateProjectResponseRaw,
@@ -333,7 +333,7 @@ func TestCreateProjectAutoQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects",
 		RawResponse: TestCreateProjectAutoQuotasResponseRaw,
@@ -366,7 +366,7 @@ func TestCreateProjectsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects",
 		RawResponse: TestCreateProjectResponseRaw,
@@ -419,7 +419,7 @@ func TestCreateProjectsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects",
 		RawResponse: TestSingleProjectInvalidResponseRaw,
@@ -450,7 +450,7 @@ func TestCreateProjectsNoQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects",
 		RawResponse: TestCreateProjectResponseRaw,
@@ -483,7 +483,7 @@ func TestUpdateProject(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
 		RawResponse: TestUpdateProjectResponseRaw,
@@ -516,7 +516,7 @@ func TestUpdateProjectHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:        testEnv.Mux,
 		URL:        "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
 		RawRequest: TestUpdateProjectOptsRaw,
@@ -567,7 +567,7 @@ func TestUpdateProjectUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
 		RawResponse: TestSingleProjectInvalidResponseRaw,
@@ -598,7 +598,7 @@ func TestDeleteProject(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
 		Method:   http.MethodDelete,
@@ -622,7 +622,7 @@ func TestDeleteProjectHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
 		Method:   http.MethodDelete,

--- a/selvpcclient/resell/v2/projects/testing/requests_test.go
+++ b/selvpcclient/resell/v2/projects/testing/requests_test.go
@@ -16,8 +16,14 @@ func TestGetProject(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/projects/49338ac045f448e294b25d013f890317",
-		TestGetProjectResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestGetProjectResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := projects.Get(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317")
@@ -42,8 +48,14 @@ func TestGetProjectSingleQuota(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/projects/49338ac045f448e294b25d013f890317",
-		TestGetProjectResponseSingleQuotaRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestGetProjectResponseSingleQuotaRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := projects.Get(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317")
@@ -67,9 +79,14 @@ func TestGetProjectHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/projects/49338ac045f448e294b25d013f890317",
-		TestGetProjectResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestGetProjectResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	project, httpResponse, err := projects.Get(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317")
@@ -112,9 +129,14 @@ func TestGetProjectUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/projects/49338ac045f448e294b25d013f890317",
-		TestSingleProjectInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestSingleProjectInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	project, _, err := projects.Get(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317")
@@ -136,8 +158,14 @@ func TestListProjects(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/projects",
-		TestListProjectsResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects",
+		RawResponse: TestListProjectsResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := projects.List(ctx, testEnv.Client)
@@ -162,8 +190,14 @@ func TestListProjectsSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/projects",
-		TestListProjectsResponseSingleRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects",
+		RawResponse: TestListProjectsResponseSingleRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := projects.List(ctx, testEnv.Client)
@@ -187,9 +221,14 @@ func TestListProjectsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/projects",
-		TestListProjectsResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects",
+		RawResponse: TestListProjectsResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allProjects, httpResponse, err := projects.List(ctx, testEnv.Client)
@@ -232,9 +271,14 @@ func TestListProjectsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/projects",
-		TestManyProjectsInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects",
+		RawResponse: TestManyProjectsInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allProjects, _, err := projects.List(ctx, testEnv.Client)
@@ -256,9 +300,15 @@ func TestCreateProject(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/projects",
-		TestCreateProjectResponseRaw, TestCreateProjectOptsRaw, http.MethodPost, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects",
+		RawResponse: TestCreateProjectResponseRaw,
+		RawRequest:  TestCreateProjectOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateProjectOpts
@@ -283,9 +333,15 @@ func TestCreateProjectAutoQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/projects",
-		TestCreateProjectAutoQuotasResponseRaw, TestCreateProjectAutoQuotasOptsRaw,
-		http.MethodPost, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects",
+		RawResponse: TestCreateProjectAutoQuotasResponseRaw,
+		RawRequest:  TestCreateProjectAutoQuotasOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateProjectAutoQuotasOpts
@@ -310,9 +366,15 @@ func TestCreateProjectsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/projects",
-		TestCreateProjectResponseRaw, TestCreateProjectOptsRaw, http.MethodPost,
-		http.StatusBadRequest, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects",
+		RawResponse: TestCreateProjectResponseRaw,
+		RawRequest:  TestCreateProjectOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusBadRequest,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateProjectOpts
@@ -357,8 +419,15 @@ func TestCreateProjectsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/projects",
-		TestSingleProjectInvalidResponseRaw, TestCreateProjectOptsRaw, http.MethodPost, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects",
+		RawResponse: TestSingleProjectInvalidResponseRaw,
+		RawRequest:  TestCreateProjectOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateProjectOpts
@@ -381,8 +450,15 @@ func TestCreateProjectsNoQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/projects",
-		TestCreateProjectResponseRaw, TestCreateProjectNoQuotasOptsRaw, http.MethodPost, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects",
+		RawResponse: TestCreateProjectResponseRaw,
+		RawRequest:  TestCreateProjectNoQuotasOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateProjectNoQuotasOpts
@@ -407,9 +483,15 @@ func TestUpdateProject(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
-		TestUpdateProjectResponseRaw, TestUpdateProjectOptsRaw, http.MethodPatch, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
+		RawResponse: TestUpdateProjectResponseRaw,
+		RawRequest:  TestUpdateProjectOptsRaw,
+		Method:      http.MethodPatch,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	updateOpts := TestUpdateProjectOpts
@@ -434,8 +516,14 @@ func TestUpdateProjectHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
-		"", TestUpdateProjectOptsRaw, http.MethodPatch, http.StatusBadRequest, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:        testEnv.Mux,
+		URL:        "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
+		RawRequest: TestUpdateProjectOptsRaw,
+		Method:     http.MethodPatch,
+		Status:     http.StatusBadRequest,
+		CallFlag:   &endpointCalled,
+	})
 
 	ctx := context.Background()
 	updateOpts := TestUpdateProjectOpts
@@ -479,9 +567,15 @@ func TestUpdateProjectUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
-		TestSingleProjectInvalidResponseRaw, TestUpdateProjectOptsRaw, http.MethodPatch,
-		http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
+		RawResponse: TestSingleProjectInvalidResponseRaw,
+		RawRequest:  TestUpdateProjectOptsRaw,
+		Method:      http.MethodPatch,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	updateOpts := TestUpdateProjectOpts
@@ -504,8 +598,13 @@ func TestDeleteProject(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
-		"", http.MethodDelete, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
+		Method:   http.MethodDelete,
+		Status:   http.StatusOK,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	_, err := projects.Delete(ctx, testEnv.Client, "f9ede488e5f14bac8962d8c53d0af9f4")
@@ -523,8 +622,13 @@ func TestDeleteProjectHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
-		"", http.MethodDelete, http.StatusBadGateway, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/projects/f9ede488e5f14bac8962d8c53d0af9f4",
+		Method:   http.MethodDelete,
+		Status:   http.StatusBadGateway,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	httpResponse, err := projects.Delete(ctx, testEnv.Client, "f9ede488e5f14bac8962d8c53d0af9f4")

--- a/selvpcclient/resell/v2/quotas/requests.go
+++ b/selvpcclient/resell/v2/quotas/requests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/selectel/go-selvpcclient/selvpcclient"
@@ -14,7 +15,7 @@ const resourceURL = "quotas"
 // GetAll returns the total amount of resources available to be allocated to projects.
 func GetAll(ctx context.Context, client *selvpcclient.ServiceClient) ([]*Quota, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -35,7 +36,7 @@ func GetAll(ctx context.Context, client *selvpcclient.ServiceClient) ([]*Quota, 
 // GetFree returns the current amount of resources available to be allocated to projects.
 func GetFree(ctx context.Context, client *selvpcclient.ServiceClient) ([]*Quota, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, "free"}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -56,7 +57,7 @@ func GetFree(ctx context.Context, client *selvpcclient.ServiceClient) ([]*Quota,
 // GetProjectsQuotas returns the quotas info for all domain projects.
 func GetProjectsQuotas(ctx context.Context, client *selvpcclient.ServiceClient) ([]*ProjectQuota, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, "projects"}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -77,7 +78,7 @@ func GetProjectsQuotas(ctx context.Context, client *selvpcclient.ServiceClient) 
 // GetProjectQuotas returns the quotas info for a single project referenced by id.
 func GetProjectQuotas(ctx context.Context, client *selvpcclient.ServiceClient, id string) ([]*Quota, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, "projects", id}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -103,7 +104,7 @@ func UpdateProjectQuotas(ctx context.Context, client *selvpcclient.ServiceClient
 	}
 
 	url := strings.Join([]string{client.Endpoint, resourceURL, "projects", id}, "/")
-	responseResult, err := client.DoRequest(ctx, "PATCH", url, bytes.NewReader(requestBody))
+	responseResult, err := client.DoRequest(ctx, http.MethodPatch, url, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/selvpcclient/resell/v2/quotas/requests_opts.go
+++ b/selvpcclient/resell/v2/quotas/requests_opts.go
@@ -2,7 +2,7 @@ package quotas
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 )
 
 // QuotaOpts represents quota options for a single resource that can be used in the update request.
@@ -54,7 +54,7 @@ We need it to marshal structure to a a JSON that the Resell v2 API wants:
 func (opts *UpdateProjectQuotasOpts) MarshalJSON() ([]byte, error) {
 	// Check the opts.
 	if len(opts.QuotasOpts) == 0 {
-		return nil, fmt.Errorf("got empty QuotasOpts")
+		return nil, errors.New("got empty QuotasOpts")
 	}
 
 	// Convert opts's quotas update options slice to a map that has resource names

--- a/selvpcclient/resell/v2/quotas/testing/requests_test.go
+++ b/selvpcclient/resell/v2/quotas/testing/requests_test.go
@@ -16,8 +16,14 @@ func TestGetAllQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas",
-		TestGetAllQuotasResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas",
+		RawResponse: TestGetAllQuotasResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := quotas.GetAll(ctx, testEnv.Client)
@@ -51,8 +57,14 @@ func TestGetAllQuotasSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas",
-		TestGetAllQuotasResponseSingleRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas",
+		RawResponse: TestGetAllQuotasResponseSingleRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := quotas.GetAll(ctx, testEnv.Client)
@@ -76,9 +88,14 @@ func TestGetAllQuotasHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas",
-		TestGetAllQuotasResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas",
+		RawResponse: TestGetAllQuotasResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allQuotas, httpResponse, err := quotas.GetAll(ctx, testEnv.Client)
@@ -121,9 +138,14 @@ func TestGetAllQuotasUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas",
-		TestQuotasInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas",
+		RawResponse: TestQuotasInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allQuotas, _, err := quotas.GetAll(ctx, testEnv.Client)
@@ -145,8 +167,14 @@ func TestGetFreeQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas/free",
-		TestGetFreeQuotasResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/free",
+		RawResponse: TestGetFreeQuotasResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := quotas.GetFree(ctx, testEnv.Client)
@@ -180,8 +208,14 @@ func TestGetFreeQuotasSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas/free",
-		TestGetFreeQuotasResponseSingleRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/free",
+		RawResponse: TestGetFreeQuotasResponseSingleRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := quotas.GetFree(ctx, testEnv.Client)
@@ -205,9 +239,14 @@ func TestGetFreeQuotasHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas/free",
-		TestGetFreeQuotasResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/free",
+		RawResponse: TestGetFreeQuotasResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allQuotas, httpResponse, err := quotas.GetFree(ctx, testEnv.Client)
@@ -250,9 +289,14 @@ func TestGetFreeQuotasUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas/free",
-		TestQuotasInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/free",
+		RawResponse: TestQuotasInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allQuotas, _, err := quotas.GetFree(ctx, testEnv.Client)
@@ -274,8 +318,14 @@ func TestGetProjectsQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas/projects",
-		TestGetProjectsQuotasResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/projects",
+		RawResponse: TestGetProjectsQuotasResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := quotas.GetProjectsQuotas(ctx, testEnv.Client)
@@ -309,8 +359,14 @@ func TestGetProjectsQuotasSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas/projects",
-		TestGetProjectsQuotasResponseSingleRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/projects",
+		RawResponse: TestGetProjectsQuotasResponseSingleRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := quotas.GetProjectsQuotas(ctx, testEnv.Client)
@@ -334,9 +390,14 @@ func TestGetProjectsQuotasHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas/projects",
-		TestGetProjectsQuotasResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/projects",
+		RawResponse: TestGetProjectsQuotasResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allQuotas, httpResponse, err := quotas.GetProjectsQuotas(ctx, testEnv.Client)
@@ -379,9 +440,14 @@ func TestGetProjectsQuotasUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas/projects",
-		TestQuotasInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/projects",
+		RawResponse: TestQuotasInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allQuotas, _, err := quotas.GetProjectsQuotas(ctx, testEnv.Client)
@@ -403,8 +469,14 @@ func TestGetProjectQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
-		TestGetProjectQuotasResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
+		RawResponse: TestGetProjectQuotasResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := quotas.GetProjectQuotas(ctx, testEnv.Client, "c83243b3c18a4d109a5f0fe45336af85")
@@ -438,8 +510,14 @@ func TestGetProjectQuotasSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
-		TestGetProjectQuotasResponseSingleRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
+		RawResponse: TestGetProjectQuotasResponseSingleRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := quotas.GetProjectQuotas(ctx, testEnv.Client, "c83243b3c18a4d109a5f0fe45336af85")
@@ -463,9 +541,14 @@ func TestGetProjectQuotasHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
-		TestGetProjectQuotasResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
+		RawResponse: TestGetProjectQuotasResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allQuotas, httpResponse, err := quotas.GetProjectQuotas(ctx, testEnv.Client, "c83243b3c18a4d109a5f0fe45336af85")
@@ -508,9 +591,14 @@ func TestGetProjectQuotasUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
-		TestQuotasInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
+		RawResponse: TestQuotasInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allQuotas, _, err := quotas.GetProjectQuotas(ctx, testEnv.Client, "c83243b3c18a4d109a5f0fe45336af85")
@@ -532,9 +620,15 @@ func TestUpdateProjectQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
-		TestUpdateProjectQuotasResponseRaw, TestUpdateQuotasOptsRaw, http.MethodPatch, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
+		RawResponse: TestUpdateProjectQuotasResponseRaw,
+		RawRequest:  TestUpdateQuotasOptsRaw,
+		Method:      http.MethodPatch,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	updateOpts := TestUpdateQuotasOpts
@@ -559,8 +653,14 @@ func TestUpdateProjectQuotasHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
-		"", TestUpdateQuotasOptsRaw, http.MethodPatch, http.StatusBadRequest, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:        testEnv.Mux,
+		URL:        "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
+		RawRequest: TestUpdateQuotasOptsRaw,
+		Method:     http.MethodPatch,
+		Status:     http.StatusBadRequest,
+		CallFlag:   &endpointCalled,
+	})
 
 	ctx := context.Background()
 	updateOpts := TestUpdateQuotasOpts
@@ -604,9 +704,15 @@ func TestUpdateProjectQuotasUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
-		TestQuotasInvalidResponseRaw, TestUpdateQuotasOptsRaw, http.MethodPatch,
-		http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
+		RawResponse: TestQuotasInvalidResponseRaw,
+		RawRequest:  TestUpdateQuotasOptsRaw,
+		Method:      http.MethodPatch,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	updateOpts := TestUpdateQuotasOpts

--- a/selvpcclient/resell/v2/quotas/testing/requests_test.go
+++ b/selvpcclient/resell/v2/quotas/testing/requests_test.go
@@ -143,7 +143,7 @@ func TestGetAllQuotasUnmarshalError(t *testing.T) {
 		URL:         "/resell/v2/quotas",
 		RawResponse: TestQuotasInvalidResponseRaw,
 		Method:      http.MethodGet,
-		Status:      http.StatusBadGateway,
+		Status:      http.StatusOK,
 		CallFlag:    &endpointCalled,
 	})
 

--- a/selvpcclient/resell/v2/quotas/testing/requests_test.go
+++ b/selvpcclient/resell/v2/quotas/testing/requests_test.go
@@ -16,7 +16,7 @@ func TestGetAllQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas",
 		RawResponse: TestGetAllQuotasResponseRaw,
@@ -57,7 +57,7 @@ func TestGetAllQuotasSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas",
 		RawResponse: TestGetAllQuotasResponseSingleRaw,
@@ -88,7 +88,7 @@ func TestGetAllQuotasHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas",
 		RawResponse: TestGetAllQuotasResponseRaw,
@@ -138,7 +138,7 @@ func TestGetAllQuotasUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas",
 		RawResponse: TestQuotasInvalidResponseRaw,
@@ -167,7 +167,7 @@ func TestGetFreeQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/free",
 		RawResponse: TestGetFreeQuotasResponseRaw,
@@ -208,7 +208,7 @@ func TestGetFreeQuotasSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/free",
 		RawResponse: TestGetFreeQuotasResponseSingleRaw,
@@ -239,7 +239,7 @@ func TestGetFreeQuotasHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/free",
 		RawResponse: TestGetFreeQuotasResponseRaw,
@@ -289,7 +289,7 @@ func TestGetFreeQuotasUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/free",
 		RawResponse: TestQuotasInvalidResponseRaw,
@@ -318,7 +318,7 @@ func TestGetProjectsQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/projects",
 		RawResponse: TestGetProjectsQuotasResponseRaw,
@@ -359,7 +359,7 @@ func TestGetProjectsQuotasSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/projects",
 		RawResponse: TestGetProjectsQuotasResponseSingleRaw,
@@ -390,7 +390,7 @@ func TestGetProjectsQuotasHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/projects",
 		RawResponse: TestGetProjectsQuotasResponseRaw,
@@ -440,7 +440,7 @@ func TestGetProjectsQuotasUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/projects",
 		RawResponse: TestQuotasInvalidResponseRaw,
@@ -469,7 +469,7 @@ func TestGetProjectQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
 		RawResponse: TestGetProjectQuotasResponseRaw,
@@ -510,7 +510,7 @@ func TestGetProjectQuotasSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
 		RawResponse: TestGetProjectQuotasResponseSingleRaw,
@@ -541,7 +541,7 @@ func TestGetProjectQuotasHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
 		RawResponse: TestGetProjectQuotasResponseRaw,
@@ -591,7 +591,7 @@ func TestGetProjectQuotasUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
 		RawResponse: TestQuotasInvalidResponseRaw,
@@ -620,7 +620,7 @@ func TestUpdateProjectQuotas(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
 		RawResponse: TestUpdateProjectQuotasResponseRaw,
@@ -653,7 +653,7 @@ func TestUpdateProjectQuotasHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:        testEnv.Mux,
 		URL:        "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
 		RawRequest: TestUpdateQuotasOptsRaw,
@@ -704,7 +704,7 @@ func TestUpdateProjectQuotasUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
 		RawResponse: TestQuotasInvalidResponseRaw,

--- a/selvpcclient/resell/v2/roles/requests.go
+++ b/selvpcclient/resell/v2/roles/requests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/selectel/go-selvpcclient/selvpcclient"
@@ -14,7 +15,7 @@ const resourceURL = "roles"
 // ListProject returns all roles in the specified project.
 func ListProject(ctx context.Context, client *selvpcclient.ServiceClient, id string) ([]*Role, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, "projects", id}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -37,7 +38,7 @@ func ListProject(ctx context.Context, client *selvpcclient.ServiceClient, id str
 // ListUser returns all roles that are associated with the specified user.
 func ListUser(ctx context.Context, client *selvpcclient.ServiceClient, id string) ([]*Role, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, "users", id}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -60,7 +61,7 @@ func ListUser(ctx context.Context, client *selvpcclient.ServiceClient, id string
 // Create requests a creation of the single role for the specified project and user.
 func Create(ctx context.Context, client *selvpcclient.ServiceClient, createOpts RoleOpt) (*Role, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, "projects", createOpts.ProjectID, "users", createOpts.UserID}, "/")
-	responseResult, err := client.DoRequest(ctx, "POST", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -89,7 +90,7 @@ func CreateBulk(ctx context.Context, client *selvpcclient.ServiceClient, createO
 	}
 
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
-	responseResult, err := client.DoRequest(ctx, "POST", url, bytes.NewReader(requestBody))
+	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -112,7 +113,7 @@ func CreateBulk(ctx context.Context, client *selvpcclient.ServiceClient, createO
 // Delete requests a deletion of the single role for the specified project and user.
 func Delete(ctx context.Context, client *selvpcclient.ServiceClient, deleteOpts RoleOpt) (*selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, "projects", deleteOpts.ProjectID, "users", deleteOpts.UserID}, "/")
-	responseResult, err := client.DoRequest(ctx, "DELETE", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/selvpcclient/resell/v2/roles/testing/requests_test.go
+++ b/selvpcclient/resell/v2/roles/testing/requests_test.go
@@ -16,7 +16,7 @@ func TestListRolesProject(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestListProjectResponseRaw,
@@ -52,7 +52,7 @@ func TestListRolesProjectSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestListResponseSingleRaw,
@@ -83,7 +83,7 @@ func TestListRolesProjectHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestListProjectResponseRaw,
@@ -133,7 +133,7 @@ func TestListRolesProjectUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestManyRolesInvalidResponseRaw,
@@ -162,7 +162,7 @@ func TestListRolesUser(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles/users/763eecfaeb0c8e9b76ab12a82eb4c11",
 		RawResponse: TestListUserResponseRaw,
@@ -198,7 +198,7 @@ func TestListRolesUserSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles/users/763eecfaeb0c8e9b76ab12a82eb4c11",
 		RawResponse: TestListResponseSingleRaw,
@@ -229,7 +229,7 @@ func TestListRolesUserHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles/users/763eecfaeb0c8e9b76ab12a82eb4c11",
 		RawResponse: TestListUserResponseRaw,
@@ -279,7 +279,7 @@ func TestListRolesUserUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles/users/763eecfaeb0c8e9b76ab12a82eb4c11",
 		RawResponse: TestManyRolesInvalidResponseRaw,
@@ -308,7 +308,7 @@ func TestCreateRole(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
 		RawResponse: TestCreateRoleResponseRaw,
@@ -340,7 +340,7 @@ func TestCreateRoleHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
 		RawResponse: TestCreateRoleResponseRaw,
@@ -392,7 +392,7 @@ func TestCreateRoleUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
 		RawResponse: TestSingleRoleInvalidResponseRaw,
@@ -422,7 +422,7 @@ func TestCreateRolesBulk(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles",
 		RawResponse: TestCreateRolesResponseRaw,
@@ -460,7 +460,7 @@ func TestCreateRolesBulkHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles",
 		RawResponse: TestCreateRolesResponseRaw,
@@ -513,7 +513,7 @@ func TestCreateRolesBulkUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/roles",
 		RawResponse: TestManyRolesInvalidResponseRaw,
@@ -544,7 +544,7 @@ func TestDeleteRole(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
 		Method:   http.MethodDelete,
@@ -569,7 +569,7 @@ func TestDeleteRoleHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
 		Method:   http.MethodDelete,

--- a/selvpcclient/resell/v2/roles/testing/requests_test.go
+++ b/selvpcclient/resell/v2/roles/testing/requests_test.go
@@ -16,8 +16,14 @@ func TestListRolesProject(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317",
-		TestListProjectResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestListProjectResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := roles.ListProject(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317")
@@ -46,8 +52,14 @@ func TestListRolesProjectSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317",
-		TestListResponseSingleRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestListResponseSingleRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := roles.ListProject(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317")
@@ -71,9 +83,14 @@ func TestListRolesProjectHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317",
-		TestListProjectResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestListProjectResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allRoles, httpResponse, err := roles.ListProject(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317")
@@ -116,9 +133,14 @@ func TestListRolesProjectUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317",
-		TestManyRolesInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestManyRolesInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allRoles, _, err := roles.ListProject(ctx, testEnv.Client, "49338ac045f448e294b25d013f890317")
@@ -140,8 +162,14 @@ func TestListRolesUser(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/roles/users/763eecfaeb0c8e9b76ab12a82eb4c11",
-		TestListUserResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles/users/763eecfaeb0c8e9b76ab12a82eb4c11",
+		RawResponse: TestListUserResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := roles.ListUser(ctx, testEnv.Client, "763eecfaeb0c8e9b76ab12a82eb4c11")
@@ -170,8 +198,14 @@ func TestListRolesUserSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/roles/users/763eecfaeb0c8e9b76ab12a82eb4c11",
-		TestListResponseSingleRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles/users/763eecfaeb0c8e9b76ab12a82eb4c11",
+		RawResponse: TestListResponseSingleRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := roles.ListUser(ctx, testEnv.Client, "763eecfaeb0c8e9b76ab12a82eb4c11")
@@ -195,9 +229,14 @@ func TestListRolesUserHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/roles/users/763eecfaeb0c8e9b76ab12a82eb4c11",
-		TestListUserResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles/users/763eecfaeb0c8e9b76ab12a82eb4c11",
+		RawResponse: TestListUserResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allRoles, httpResponse, err := roles.ListUser(ctx, testEnv.Client, "763eecfaeb0c8e9b76ab12a82eb4c11")
@@ -240,9 +279,14 @@ func TestListRolesUserUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/roles/users/763eecfaeb0c8e9b76ab12a82eb4c11",
-		TestManyRolesInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles/users/763eecfaeb0c8e9b76ab12a82eb4c11",
+		RawResponse: TestManyRolesInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allRoles, _, err := roles.ListUser(ctx, testEnv.Client, "763eecfaeb0c8e9b76ab12a82eb4c11")
@@ -264,9 +308,14 @@ func TestCreateRole(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux,
-		"/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
-		TestCreateRoleResponseRaw, http.MethodPost, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
+		RawResponse: TestCreateRoleResponseRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestRoleOpt
@@ -291,9 +340,14 @@ func TestCreateRoleHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux,
-		"/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
-		TestCreateRoleResponseRaw, http.MethodPost, http.StatusBadGateway, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
+		RawResponse: TestCreateRoleResponseRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestRoleOpt
@@ -338,9 +392,14 @@ func TestCreateRoleUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux,
-		"/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
-		TestSingleRoleInvalidResponseRaw, http.MethodPost, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
+		RawResponse: TestSingleRoleInvalidResponseRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestRoleOpt
@@ -363,9 +422,15 @@ func TestCreateRolesBulk(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/roles",
-		TestCreateRolesResponseRaw, TestCreateRolesOptsRaw, http.MethodPost, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles",
+		RawResponse: TestCreateRolesResponseRaw,
+		RawRequest:  TestCreateRolesOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateRolesOpts
@@ -395,9 +460,15 @@ func TestCreateRolesBulkHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/roles",
-		TestCreateRolesResponseRaw, TestCreateRolesOptsRaw, http.MethodPost,
-		http.StatusBadGateway, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles",
+		RawResponse: TestCreateRolesResponseRaw,
+		RawRequest:  TestCreateRolesOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateRolesOpts
@@ -442,9 +513,15 @@ func TestCreateRolesBulkUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/roles",
-		TestManyRolesInvalidResponseRaw, TestCreateRolesOptsRaw, http.MethodPost,
-		http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/roles",
+		RawResponse: TestManyRolesInvalidResponseRaw,
+		RawRequest:  TestCreateRolesOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateRolesOpts
@@ -467,9 +544,13 @@ func TestDeleteRole(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux,
-		"/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
-		"", http.MethodDelete, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
+		Method:   http.MethodDelete,
+		Status:   http.StatusOK,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	deleteOpts := TestRoleOpt
@@ -488,9 +569,13 @@ func TestDeleteRoleHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux,
-		"/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
-		"", http.MethodDelete, http.StatusBadGateway, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/roles/projects/49338ac045f448e294b25d013f890317/users/763eecfaeb0c8e9b76ab12a82eb4c11",
+		Method:   http.MethodDelete,
+		Status:   http.StatusBadGateway,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	deleteOpts := TestRoleOpt

--- a/selvpcclient/resell/v2/subnets/requests.go
+++ b/selvpcclient/resell/v2/subnets/requests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/selectel/go-selvpcclient/selvpcclient"
@@ -14,7 +15,7 @@ const resourceURL = "subnets"
 // Get returns a single subnet by its id.
 func Get(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*Subnet, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -46,7 +47,7 @@ func List(ctx context.Context, client *selvpcclient.ServiceClient, opts ListOpts
 		url = strings.Join([]string{url, queryParams}, "?")
 	}
 
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,7 +76,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, projectID s
 	}
 
 	url := strings.Join([]string{client.Endpoint, resourceURL, "projects", projectID}, "/")
-	responseResult, err := client.DoRequest(ctx, "POST", url, bytes.NewReader(requestBody))
+	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -98,7 +99,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, projectID s
 // Delete deletes a single subnet by its id.
 func Delete(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "DELETE", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/selvpcclient/resell/v2/subnets/testing/requests_test.go
+++ b/selvpcclient/resell/v2/subnets/testing/requests_test.go
@@ -16,8 +16,14 @@ func TestGetSubnet(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/subnets/111122",
-		TestGetSubnetResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/subnets/111122",
+		RawResponse: TestGetSubnetResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := subnets.Get(ctx, testEnv.Client, "111122")
@@ -41,9 +47,14 @@ func TestGetSubnetHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/subnets/111122",
-		TestGetSubnetResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/subnets/111122",
+		RawResponse: TestGetSubnetResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	subnet, httpResponse, err := subnets.Get(ctx, testEnv.Client, "111122")
@@ -86,9 +97,14 @@ func TestGetSubnetUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/subnets/111122",
-		TestSingleSubnetInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/subnets/111122",
+		RawResponse: TestSingleSubnetInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	subnet, _, err := subnets.Get(ctx, testEnv.Client, "111122")
@@ -110,8 +126,14 @@ func TestListSubnets(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/subnets",
-		TestListSubnetsResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/subnets",
+		RawResponse: TestListSubnetsResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := subnets.List(ctx, testEnv.Client, subnets.ListOpts{})
@@ -140,8 +162,14 @@ func TestListSubnetsSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/subnets",
-		TestListSubnetsSingleResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/subnets",
+		RawResponse: TestListSubnetsSingleResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := subnets.List(ctx, testEnv.Client, subnets.ListOpts{})
@@ -165,9 +193,14 @@ func TestListSubnetsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/subnets",
-		TestListSubnetsResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/subnets",
+		RawResponse: TestListSubnetsResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allSubnet, httpResponse, err := subnets.List(ctx, testEnv.Client, subnets.ListOpts{})
@@ -210,9 +243,14 @@ func TestListSubnetsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/subnets",
-		TestManySubnetsInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/subnets",
+		RawResponse: TestManySubnetsInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allSubnet, _, err := subnets.List(ctx, testEnv.Client, subnets.ListOpts{})
@@ -234,9 +272,15 @@ func TestCreateSubnets(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/subnets/projects/9c97bdc75295493096cf5edcb8c37933",
-		TestCreateSubnetsResponseRaw, TestCreateSubnetsOptsRaw, http.MethodPost,
-		http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/subnets/projects/9c97bdc75295493096cf5edcb8c37933",
+		RawResponse: TestCreateSubnetsResponseRaw,
+		RawRequest:  TestCreateSubnetsOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateSubnetsOpts
@@ -261,9 +305,15 @@ func TestCreateSubnetsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/subnets/projects/9c97bdc75295493096cf5edcb8c37933",
-		TestCreateSubnetsResponseRaw, TestCreateSubnetsOptsRaw, http.MethodPost,
-		http.StatusBadRequest, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/subnets/projects/9c97bdc75295493096cf5edcb8c37933",
+		RawResponse: TestCreateSubnetsResponseRaw,
+		RawRequest:  TestCreateSubnetsOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusBadRequest,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateSubnetsOpts
@@ -309,8 +359,15 @@ func TestCreateSubnetsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/subnets/projects/9c97bdc75295493096cf5edcb8c37933",
-		TestManySubnetsInvalidResponseRaw, TestCreateSubnetsOptsRaw, http.MethodPost, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/subnets/projects/9c97bdc75295493096cf5edcb8c37933",
+		RawResponse: TestManySubnetsInvalidResponseRaw,
+		RawRequest:  TestCreateSubnetsOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateSubnetsOpts
@@ -333,8 +390,13 @@ func TestDeleteSubnet(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/subnets/112233", "",
-		http.MethodDelete, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/subnets/112233",
+		Method:   http.MethodDelete,
+		Status:   http.StatusOK,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	_, err := subnets.Delete(ctx, testEnv.Client, "112233")
@@ -353,8 +415,13 @@ func TestDeleteSubnetHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/subnets/112233",
-		"", http.MethodDelete, http.StatusBadGateway, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/subnets/112233",
+		Method:   http.MethodDelete,
+		Status:   http.StatusBadGateway,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	httpResponse, err := subnets.Delete(ctx, testEnv.Client, "112233")

--- a/selvpcclient/resell/v2/subnets/testing/requests_test.go
+++ b/selvpcclient/resell/v2/subnets/testing/requests_test.go
@@ -16,7 +16,7 @@ func TestGetSubnet(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/subnets/111122",
 		RawResponse: TestGetSubnetResponseRaw,
@@ -47,7 +47,7 @@ func TestGetSubnetHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/subnets/111122",
 		RawResponse: TestGetSubnetResponseRaw,
@@ -97,7 +97,7 @@ func TestGetSubnetUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/subnets/111122",
 		RawResponse: TestSingleSubnetInvalidResponseRaw,
@@ -126,7 +126,7 @@ func TestListSubnets(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/subnets",
 		RawResponse: TestListSubnetsResponseRaw,
@@ -162,7 +162,7 @@ func TestListSubnetsSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/subnets",
 		RawResponse: TestListSubnetsSingleResponseRaw,
@@ -193,7 +193,7 @@ func TestListSubnetsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/subnets",
 		RawResponse: TestListSubnetsResponseRaw,
@@ -243,7 +243,7 @@ func TestListSubnetsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/subnets",
 		RawResponse: TestManySubnetsInvalidResponseRaw,
@@ -272,7 +272,7 @@ func TestCreateSubnets(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/subnets/projects/9c97bdc75295493096cf5edcb8c37933",
 		RawResponse: TestCreateSubnetsResponseRaw,
@@ -305,7 +305,7 @@ func TestCreateSubnetsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/subnets/projects/9c97bdc75295493096cf5edcb8c37933",
 		RawResponse: TestCreateSubnetsResponseRaw,
@@ -359,7 +359,7 @@ func TestCreateSubnetsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/subnets/projects/9c97bdc75295493096cf5edcb8c37933",
 		RawResponse: TestManySubnetsInvalidResponseRaw,
@@ -390,7 +390,7 @@ func TestDeleteSubnet(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/subnets/112233",
 		Method:   http.MethodDelete,
@@ -415,7 +415,7 @@ func TestDeleteSubnetHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/subnets/112233",
 		Method:   http.MethodDelete,

--- a/selvpcclient/resell/v2/tokens/requests.go
+++ b/selvpcclient/resell/v2/tokens/requests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/selectel/go-selvpcclient/selvpcclient"
@@ -24,7 +25,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, createOpts 
 	}
 
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
-	responseResult, err := client.DoRequest(ctx, "POST", url, bytes.NewReader(requestBody))
+	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/selvpcclient/resell/v2/tokens/testing/requests_test.go
+++ b/selvpcclient/resell/v2/tokens/testing/requests_test.go
@@ -16,7 +16,7 @@ func TestCreateToken(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/tokens",
 		RawResponse: TestCreateTokenResponseRaw,
@@ -49,7 +49,7 @@ func TestCreateTokenHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/tokens",
 		RawResponse: TestCreateTokenResponseRaw,
@@ -102,7 +102,7 @@ func TestCreateTokenUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/tokens",
 		RawResponse: TestTokenInvalidResponseRaw,

--- a/selvpcclient/resell/v2/tokens/testing/requests_test.go
+++ b/selvpcclient/resell/v2/tokens/testing/requests_test.go
@@ -16,9 +16,15 @@ func TestCreateToken(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/tokens",
-		TestCreateTokenResponseRaw, TestCreateTokenOptsRaw, http.MethodPost, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/tokens",
+		RawResponse: TestCreateTokenResponseRaw,
+		RawRequest:  TestCreateTokenOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateTokenOpts
@@ -43,9 +49,15 @@ func TestCreateTokenHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/tokens",
-		TestCreateTokenResponseRaw, TestCreateTokenOptsRaw, http.MethodPost,
-		http.StatusBadRequest, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/tokens",
+		RawResponse: TestCreateTokenResponseRaw,
+		RawRequest:  TestCreateTokenOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusBadRequest,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateTokenOpts
@@ -90,8 +102,15 @@ func TestCreateTokenUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/tokens",
-		TestTokenInvalidResponseRaw, TestCreateTokenOptsRaw, http.MethodPost, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/tokens",
+		RawResponse: TestTokenInvalidResponseRaw,
+		RawRequest:  TestCreateTokenOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateTokenOpts

--- a/selvpcclient/resell/v2/traffic/requests.go
+++ b/selvpcclient/resell/v2/traffic/requests.go
@@ -2,6 +2,7 @@ package traffic
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"github.com/selectel/go-selvpcclient/selvpcclient"
@@ -12,7 +13,7 @@ const resourceURL = "traffic"
 // Get returns the domain traffic information.
 func Get(ctx context.Context, client *selvpcclient.ServiceClient) (*DomainTraffic, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/selvpcclient/resell/v2/traffic/testing/requests_test.go
+++ b/selvpcclient/resell/v2/traffic/testing/requests_test.go
@@ -16,7 +16,7 @@ func TestGetDomainTraffic(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/traffic",
 		RawResponse: TestGetTrafficRaw,
@@ -52,7 +52,7 @@ func TestGetDomainTrafficUsed(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/traffic",
 		RawResponse: TestGetTrafficUsedRaw,
@@ -83,7 +83,7 @@ func TestGetDomainTrafficHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/traffic",
 		RawResponse: TestGetTrafficRaw,
@@ -133,7 +133,7 @@ func TestGetTrafficInvalidTimestampsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/traffic",
 		RawResponse: TestGetTrafficInvalidTimestampsRaw,
@@ -162,7 +162,7 @@ func TestGetTrafficInvalidResponseUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/traffic",
 		RawResponse: TestGetTrafficInvalidDataResponseRaw,

--- a/selvpcclient/resell/v2/traffic/testing/requests_test.go
+++ b/selvpcclient/resell/v2/traffic/testing/requests_test.go
@@ -26,7 +26,7 @@ func TestGetDomainTraffic(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	actual, _, err := traffic.Get(ctx, testEnv.Client)
+	tr, _, err := traffic.Get(ctx, testEnv.Client)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,15 +34,15 @@ func TestGetDomainTraffic(t *testing.T) {
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
 	}
-	if actual == nil {
+	if tr == nil {
 		t.Fatal("didn't get traffic")
 	}
-	actualKind := reflect.TypeOf(actual.DomainData).Kind()
+	actualKind := reflect.TypeOf(tr.DomainData).Kind()
 	if actualKind != reflect.Slice {
 		t.Errorf("expected slice of pointers to traffic data, but got %v", actualKind)
 	}
-	if len(actual.DomainData) != 3 {
-		t.Errorf("expected 3 traffic data structures, but got %d", len(actual.DomainData))
+	if len(tr.DomainData) != 3 {
+		t.Errorf("expected 3 traffic data structures, but got %d", len(tr.DomainData))
 	}
 }
 
@@ -62,7 +62,7 @@ func TestGetDomainTrafficUsed(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	actual, _, err := traffic.Get(ctx, testEnv.Client)
+	tr, _, err := traffic.Get(ctx, testEnv.Client)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,8 +72,8 @@ func TestGetDomainTrafficUsed(t *testing.T) {
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
 	}
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("expected %#v, but got %#v", expected, actual)
+	if !reflect.DeepEqual(tr, expected) {
+		t.Fatalf("expected %#v, but got %#v", expected, tr)
 	}
 }
 
@@ -93,12 +93,12 @@ func TestGetDomainTrafficHTTPError(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	traffic, httpResponse, err := traffic.Get(ctx, testEnv.Client)
+	tr, httpResponse, err := traffic.Get(ctx, testEnv.Client)
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
 	}
-	if traffic != nil {
+	if tr != nil {
 		t.Fatal("expected no traffic from the Get method")
 	}
 	if err == nil {
@@ -117,9 +117,9 @@ func TestGetTrafficTimeoutError(t *testing.T) {
 	testEnv.NewTestResellV2Client()
 
 	ctx := context.Background()
-	traffic, _, err := traffic.Get(ctx, testEnv.Client)
+	tr, _, err := traffic.Get(ctx, testEnv.Client)
 
-	if traffic != nil {
+	if tr != nil {
 		t.Fatal("expected no traffic from the Get method")
 	}
 	if err == nil {
@@ -143,12 +143,12 @@ func TestGetTrafficInvalidTimestampsUnmarshalError(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	traffic, _, err := traffic.Get(ctx, testEnv.Client)
+	tr, _, err := traffic.Get(ctx, testEnv.Client)
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
 	}
-	if traffic != nil {
+	if tr != nil {
 		t.Fatal("expected no traffic from the Get method")
 	}
 	if err == nil {
@@ -172,12 +172,12 @@ func TestGetTrafficInvalidResponseUnmarshalError(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	traffic, _, err := traffic.Get(ctx, testEnv.Client)
+	tr, _, err := traffic.Get(ctx, testEnv.Client)
 
 	if !endpointCalled {
 		t.Fatal("endpoint wasn't called")
 	}
-	if traffic != nil {
+	if tr != nil {
 		t.Fatal("expected no traffic from the Get method")
 	}
 	if err == nil {

--- a/selvpcclient/resell/v2/traffic/testing/requests_test.go
+++ b/selvpcclient/resell/v2/traffic/testing/requests_test.go
@@ -16,8 +16,14 @@ func TestGetDomainTraffic(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/traffic",
-		TestGetTrafficRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/traffic",
+		RawResponse: TestGetTrafficRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := traffic.Get(ctx, testEnv.Client)
@@ -46,8 +52,14 @@ func TestGetDomainTrafficUsed(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/traffic",
-		TestGetTrafficUsedRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/traffic",
+		RawResponse: TestGetTrafficUsedRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := traffic.Get(ctx, testEnv.Client)
@@ -71,8 +83,14 @@ func TestGetDomainTrafficHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/traffic",
-		TestGetTrafficRaw, http.MethodGet, http.StatusBadGateway, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/traffic",
+		RawResponse: TestGetTrafficRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	traffic, httpResponse, err := traffic.Get(ctx, testEnv.Client)
@@ -115,8 +133,14 @@ func TestGetTrafficInvalidTimestampsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/traffic",
-		TestGetTrafficInvalidTimestampsRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/traffic",
+		RawResponse: TestGetTrafficInvalidTimestampsRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	traffic, _, err := traffic.Get(ctx, testEnv.Client)
@@ -138,8 +162,14 @@ func TestGetTrafficInvalidResponseUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/traffic",
-		TestGetTrafficInvalidDataResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/traffic",
+		RawResponse: TestGetTrafficInvalidDataResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	traffic, _, err := traffic.Get(ctx, testEnv.Client)

--- a/selvpcclient/resell/v2/users/requests.go
+++ b/selvpcclient/resell/v2/users/requests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/selectel/go-selvpcclient/selvpcclient"
@@ -14,7 +15,7 @@ const resourceURL = "users"
 // List gets a list of users in the current domain.
 func List(ctx context.Context, client *selvpcclient.ServiceClient) ([]*User, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -47,7 +48,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, createOpts 
 	}
 
 	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
-	responseResult, err := client.DoRequest(ctx, "POST", url, bytes.NewReader(requestBody))
+	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -80,7 +81,7 @@ func Update(ctx context.Context, client *selvpcclient.ServiceClient, id string, 
 	}
 
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "PATCH", url, bytes.NewReader(requestBody))
+	responseResult, err := client.DoRequest(ctx, http.MethodPatch, url, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -103,7 +104,7 @@ func Update(ctx context.Context, client *selvpcclient.ServiceClient, id string, 
 // Delete deletes a single user by its id.
 func Delete(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "DELETE", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/selvpcclient/resell/v2/users/testing/requests_test.go
+++ b/selvpcclient/resell/v2/users/testing/requests_test.go
@@ -16,8 +16,14 @@ func TestListUsers(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/users",
-		TestListUsersResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/users",
+		RawResponse: TestListUsersResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := users.List(ctx, testEnv.Client)
@@ -46,9 +52,14 @@ func TestListUsersSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/users",
-		TestListUsersSingleUserResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/users",
+		RawResponse: TestListUsersSingleUserResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := users.List(ctx, testEnv.Client)
@@ -72,9 +83,14 @@ func TestListUsersHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/users",
-		TestListUsersSingleUserResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/users",
+		RawResponse: TestListUsersSingleUserResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allUsers, httpResponse, err := users.List(ctx, testEnv.Client)
@@ -117,9 +133,14 @@ func TestListUsersUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/users",
-		TestManyUsersInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/users",
+		RawResponse: TestManyUsersInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allUsers, _, err := users.List(ctx, testEnv.Client)
@@ -141,9 +162,15 @@ func TestCreateUser(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/users",
-		TestCreateUserResponseRaw, TestCreateUserOptsRaw, http.MethodPost,
-		http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/users",
+		RawResponse: TestCreateUserResponseRaw,
+		RawRequest:  TestCreateUserOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateUserOpts
@@ -168,8 +195,14 @@ func TestCreateUserHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/users", "",
-		TestCreateUserOptsRaw, http.MethodPost, http.StatusBadRequest, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:        testEnv.Mux,
+		URL:        "/resell/v2/users",
+		RawRequest: TestCreateUserOptsRaw,
+		Method:     http.MethodPost,
+		Status:     http.StatusBadRequest,
+		CallFlag:   &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateUserOpts
@@ -213,8 +246,15 @@ func TestCreateUserUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/users", TestSingleUserInvalidResponseRaw,
-		TestCreateUserOptsRaw, http.MethodPost, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/users",
+		RawResponse: TestSingleUserInvalidResponseRaw,
+		RawRequest:  TestCreateUserOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateUserOpts
@@ -237,9 +277,15 @@ func TestUpdateUser(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
-		TestUpdateUserResponseRaw, TestUpdateUserOptsRaw, http.MethodPatch, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
+		RawResponse: TestUpdateUserResponseRaw,
+		RawRequest:  TestUpdateUserOptsRaw,
+		Method:      http.MethodPatch,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	updateOpts := TestUpdateUserOpts
@@ -264,8 +310,14 @@ func TestUpdateUserHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
-		"", TestUpdateUserOptsRaw, http.MethodPatch, http.StatusBadRequest, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:        testEnv.Mux,
+		URL:        "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
+		RawRequest: TestUpdateUserOptsRaw,
+		Method:     http.MethodPatch,
+		Status:     http.StatusBadRequest,
+		CallFlag:   &endpointCalled,
+	})
 
 	ctx := context.Background()
 	updateOpts := TestUpdateUserOpts
@@ -309,9 +361,15 @@ func TestUpdateUserUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
-		TestSingleUserInvalidResponseRaw, TestUpdateUserOptsRaw, http.MethodPatch,
-		http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
+		RawResponse: TestSingleUserInvalidResponseRaw,
+		RawRequest:  TestUpdateUserOptsRaw,
+		Method:      http.MethodPatch,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	updateOpts := TestUpdateUserOpts
@@ -334,8 +392,13 @@ func TestDeleteUser(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
-		"", http.MethodDelete, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
+		Method:   http.MethodDelete,
+		Status:   http.StatusOK,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	_, err := users.Delete(ctx, testEnv.Client, "4b2e452ed4c940bd87a88499eaf14c4f")
@@ -353,8 +416,13 @@ func TestDeleteUserHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
-		"", http.MethodDelete, http.StatusBadGateway, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
+		Method:   http.MethodDelete,
+		Status:   http.StatusBadGateway,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	httpResponse, err := users.Delete(ctx, testEnv.Client, "4b2e452ed4c940bd87a88499eaf14c4f")

--- a/selvpcclient/resell/v2/users/testing/requests_test.go
+++ b/selvpcclient/resell/v2/users/testing/requests_test.go
@@ -16,7 +16,7 @@ func TestListUsers(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/users",
 		RawResponse: TestListUsersResponseRaw,
@@ -52,7 +52,7 @@ func TestListUsersSingle(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/users",
 		RawResponse: TestListUsersSingleUserResponseRaw,
@@ -83,7 +83,7 @@ func TestListUsersHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/users",
 		RawResponse: TestListUsersSingleUserResponseRaw,
@@ -133,7 +133,7 @@ func TestListUsersUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/users",
 		RawResponse: TestManyUsersInvalidResponseRaw,
@@ -162,7 +162,7 @@ func TestCreateUser(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/users",
 		RawResponse: TestCreateUserResponseRaw,
@@ -195,7 +195,7 @@ func TestCreateUserHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:        testEnv.Mux,
 		URL:        "/resell/v2/users",
 		RawRequest: TestCreateUserOptsRaw,
@@ -246,7 +246,7 @@ func TestCreateUserUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/users",
 		RawResponse: TestSingleUserInvalidResponseRaw,
@@ -277,7 +277,7 @@ func TestUpdateUser(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
 		RawResponse: TestUpdateUserResponseRaw,
@@ -310,7 +310,7 @@ func TestUpdateUserHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:        testEnv.Mux,
 		URL:        "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
 		RawRequest: TestUpdateUserOptsRaw,
@@ -361,7 +361,7 @@ func TestUpdateUserUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
 		RawResponse: TestSingleUserInvalidResponseRaw,
@@ -392,7 +392,7 @@ func TestDeleteUser(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
 		Method:   http.MethodDelete,
@@ -416,7 +416,7 @@ func TestDeleteUserHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/users/4b2e452ed4c940bd87a88499eaf14c4f",
 		Method:   http.MethodDelete,

--- a/selvpcclient/resell/v2/vrrpsubnets/requests.go
+++ b/selvpcclient/resell/v2/vrrpsubnets/requests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/selectel/go-selvpcclient/selvpcclient"
@@ -14,7 +15,7 @@ const resourceURL = "vrrp_subnets"
 // Get returns a single VRRP subnet by its id.
 func Get(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*VRRPSubnet, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -46,7 +47,7 @@ func List(ctx context.Context, client *selvpcclient.ServiceClient, opts ListOpts
 		url = strings.Join([]string{url, queryParams}, "?")
 	}
 
-	responseResult, err := client.DoRequest(ctx, "GET", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,7 +76,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, projectID s
 	}
 
 	url := strings.Join([]string{client.Endpoint, resourceURL, "projects", projectID}, "/")
-	responseResult, err := client.DoRequest(ctx, "POST", url, bytes.NewReader(requestBody))
+	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -98,7 +99,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, projectID s
 // Delete deletes a single VRRP subnet by its id.
 func Delete(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
-	responseResult, err := client.DoRequest(ctx, "DELETE", url, nil)
+	responseResult, err := client.DoRequest(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/selvpcclient/resell/v2/vrrpsubnets/testing/fixtures.go
+++ b/selvpcclient/resell/v2/vrrpsubnets/testing/fixtures.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"time"
 
+	"github.com/selectel/go-selvpcclient/selvpcclient"
 	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/servers"
 	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/subnets"
 	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/vrrpsubnets"
@@ -168,7 +169,7 @@ var TestCreateVRRPSubnetsOpts = vrrpsubnets.VRRPSubnetOpts{
 				Master: "ru-2",
 				Slave:  "ru-1",
 			},
-			Type:         "ipv4",
+			Type:         selvpcclient.IPv4,
 			PrefixLength: 29,
 		},
 	},

--- a/selvpcclient/resell/v2/vrrpsubnets/testing/requests_test.go
+++ b/selvpcclient/resell/v2/vrrpsubnets/testing/requests_test.go
@@ -16,8 +16,14 @@ func TestGetVRRPSubnet(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/vrrp_subnets/186",
-		TestGetVRRPSubnetResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/vrrp_subnets/186",
+		RawResponse: TestGetVRRPSubnetResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := vrrpsubnets.Get(ctx, testEnv.Client, "186")
@@ -41,9 +47,14 @@ func TestGetVRRPSubnetHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/vrrp_subnets/186",
-		TestGetVRRPSubnetResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/vrrp_subnets/186",
+		RawResponse: TestGetVRRPSubnetResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	subnet, httpResponse, err := vrrpsubnets.Get(ctx, testEnv.Client, "186")
@@ -86,9 +97,14 @@ func TestGetVRRPSubnetUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/vrrp_subnets/186",
-		TestSingleVRRPSubnetInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/vrrp_subnets/186",
+		RawResponse: TestSingleVRRPSubnetInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	vrpsubnet, _, err := vrrpsubnets.Get(ctx, testEnv.Client, "186")
@@ -110,8 +126,14 @@ func TestListVRRPSubnets(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/vrrp_subnets",
-		TestListVRRPSubnetsResponseRaw, http.MethodGet, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/vrrp_subnets",
+		RawResponse: TestListVRRPSubnetsResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	actual, _, err := vrrpsubnets.List(ctx, testEnv.Client, vrrpsubnets.ListOpts{})
@@ -135,9 +157,14 @@ func TestListVRRPSubnetsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/vrrp_subnets",
-		TestListVRRPSubnetsResponseRaw, http.MethodGet, http.StatusBadGateway,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/vrrp_subnets",
+		RawResponse: TestListVRRPSubnetsResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allVRRPSubnets, httpResponse, err := vrrpsubnets.List(ctx, testEnv.Client, vrrpsubnets.ListOpts{})
@@ -180,9 +207,14 @@ func TestListVRRPSubnetsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/vrrp_subnets",
-		TestManyVRRPSubnetsInvalidResponseRaw, http.MethodGet, http.StatusOK,
-		&endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/vrrp_subnets",
+		RawResponse: TestManyVRRPSubnetsInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	allVRRPSubnets, _, err := vrrpsubnets.List(ctx, testEnv.Client, vrrpsubnets.ListOpts{})
@@ -204,9 +236,15 @@ func TestCreateVRRPSubnets(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/vrrp_subnets/projects/49338ac045f448e294b25d013f890317",
-		TestCreateVRRPSubnetsResponseRaw, TestCreateVRRPSubnetsOptsRaw, http.MethodPost,
-		http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/vrrp_subnets/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestCreateVRRPSubnetsResponseRaw,
+		RawRequest:  TestCreateVRRPSubnetsOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateVRRPSubnetsOpts
@@ -231,9 +269,15 @@ func TestCreateVRRPSubnetsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/vrrp_subnets/projects/49338ac045f448e294b25d013f890317",
-		TestCreateVRRPSubnetsResponseRaw, TestCreateVRRPSubnetsOptsRaw, http.MethodPost,
-		http.StatusBadRequest, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/vrrp_subnets/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestCreateVRRPSubnetsResponseRaw,
+		RawRequest:  TestCreateVRRPSubnetsOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusBadRequest,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateVRRPSubnetsOpts
@@ -279,8 +323,15 @@ func TestCreateVRRPSubnetsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(testEnv.Mux, "/resell/v2/vrrp_subnets/projects/49338ac045f448e294b25d013f890317",
-		TestManyVRRPSubnetsInvalidResponseRaw, TestCreateVRRPSubnetsOptsRaw, http.MethodPost, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/vrrp_subnets/projects/49338ac045f448e294b25d013f890317",
+		RawResponse: TestManyVRRPSubnetsInvalidResponseRaw,
+		RawRequest:  TestCreateVRRPSubnetsOptsRaw,
+		Method:      http.MethodPost,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
 
 	ctx := context.Background()
 	createOpts := TestCreateVRRPSubnetsOpts
@@ -303,8 +354,13 @@ func TestDeleteVRRPSubnet(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/vrrp_subnets/112233", "",
-		http.MethodDelete, http.StatusOK, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/vrrp_subnets/112233",
+		Method:   http.MethodDelete,
+		Status:   http.StatusOK,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	_, err := vrrpsubnets.Delete(ctx, testEnv.Client, "112233")
@@ -323,8 +379,13 @@ func TestDeleteVRRPSubnetHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(testEnv.Mux, "/resell/v2/vrrp_subnets/112233",
-		"", http.MethodDelete, http.StatusBadGateway, &endpointCalled, t)
+	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/resell/v2/vrrp_subnets/112233",
+		Method:   http.MethodDelete,
+		Status:   http.StatusBadGateway,
+		CallFlag: &endpointCalled,
+	})
 
 	ctx := context.Background()
 	httpResponse, err := vrrpsubnets.Delete(ctx, testEnv.Client, "112233")

--- a/selvpcclient/resell/v2/vrrpsubnets/testing/requests_test.go
+++ b/selvpcclient/resell/v2/vrrpsubnets/testing/requests_test.go
@@ -102,7 +102,7 @@ func TestGetVRRPSubnetUnmarshalError(t *testing.T) {
 		URL:         "/resell/v2/vrrp_subnets/186",
 		RawResponse: TestSingleVRRPSubnetInvalidResponseRaw,
 		Method:      http.MethodGet,
-		Status:      http.StatusBadGateway,
+		Status:      http.StatusOK,
 		CallFlag:    &endpointCalled,
 	})
 

--- a/selvpcclient/resell/v2/vrrpsubnets/testing/requests_test.go
+++ b/selvpcclient/resell/v2/vrrpsubnets/testing/requests_test.go
@@ -16,7 +16,7 @@ func TestGetVRRPSubnet(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/vrrp_subnets/186",
 		RawResponse: TestGetVRRPSubnetResponseRaw,
@@ -47,7 +47,7 @@ func TestGetVRRPSubnetHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/vrrp_subnets/186",
 		RawResponse: TestGetVRRPSubnetResponseRaw,
@@ -97,7 +97,7 @@ func TestGetVRRPSubnetUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/vrrp_subnets/186",
 		RawResponse: TestSingleVRRPSubnetInvalidResponseRaw,
@@ -126,7 +126,7 @@ func TestListVRRPSubnets(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/vrrp_subnets",
 		RawResponse: TestListVRRPSubnetsResponseRaw,
@@ -157,7 +157,7 @@ func TestListVRRPSubnetsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/vrrp_subnets",
 		RawResponse: TestListVRRPSubnetsResponseRaw,
@@ -207,7 +207,7 @@ func TestListVRRPSubnetsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/vrrp_subnets",
 		RawResponse: TestManyVRRPSubnetsInvalidResponseRaw,
@@ -236,7 +236,7 @@ func TestCreateVRRPSubnets(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/vrrp_subnets/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestCreateVRRPSubnetsResponseRaw,
@@ -269,7 +269,7 @@ func TestCreateVRRPSubnetsHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/vrrp_subnets/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestCreateVRRPSubnetsResponseRaw,
@@ -323,7 +323,7 @@ func TestCreateVRRPSubnetsUnmarshalError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
 		Mux:         testEnv.Mux,
 		URL:         "/resell/v2/vrrp_subnets/projects/49338ac045f448e294b25d013f890317",
 		RawResponse: TestManyVRRPSubnetsInvalidResponseRaw,
@@ -354,7 +354,7 @@ func TestDeleteVRRPSubnet(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/vrrp_subnets/112233",
 		Method:   http.MethodDelete,
@@ -379,7 +379,7 @@ func TestDeleteVRRPSubnetHTTPError(t *testing.T) {
 	testEnv := testutils.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 	testEnv.NewTestResellV2Client()
-	testutils.HandleReqWithoutBody(t, testutils.HandleReqOpts{
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
 		Mux:      testEnv.Mux,
 		URL:      "/resell/v2/vrrp_subnets/112233",
 		Method:   http.MethodDelete,

--- a/selvpcclient/selvpc.go
+++ b/selvpcclient/selvpc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -54,10 +55,10 @@ type ResponseResult struct {
 }
 
 // DoRequest performs the HTTP request with the current ServiceClient's HTTPClient.
-// Authentication and optional headers will be automatically added.
-func (client *ServiceClient) DoRequest(ctx context.Context, method, url string, body io.Reader) (*ResponseResult, error) {
+// Authentication and optional headers will be added automatically.
+func (client *ServiceClient) DoRequest(ctx context.Context, method, path string, body io.Reader) (*ResponseResult, error) {
 	// Prepare a HTTP request with the provided context.
-	request, err := http.NewRequest(method, url, body)
+	request, err := http.NewRequest(method, path, body)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +139,7 @@ type IPVersion string
 func BuildQueryParameters(opts interface{}) (string, error) {
 	optsValue := reflect.ValueOf(opts)
 	if optsValue.Kind() != reflect.Struct {
-		return "", fmt.Errorf("provided options is not a structure")
+		return "", errors.New("provided options is not a structure")
 	}
 	optsType := reflect.TypeOf(opts)
 

--- a/selvpcclient/testing/client_test.go
+++ b/selvpcclient/testing/client_test.go
@@ -19,9 +19,9 @@ func TestDoGetRequest(t *testing.T) {
 	defer testEnv.TearDownTestEnv()
 	testEnv.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, "response")
+		fmt.Fprint(w, "response")
 
-		if r.Method != "GET" {
+		if r.Method != http.MethodGet {
 			t.Errorf("got %s method, want GET", r.Method)
 		}
 	})
@@ -35,12 +35,12 @@ func TestDoGetRequest(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	response, err := client.DoRequest(ctx, "GET", endpoint, nil)
+	response, err := client.DoRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		log.Fatalf("unexpected error: %v", err)
 	}
 	if response.Body == nil {
-		log.Fatalf("response body is empty")
+		log.Fatal("response body is empty")
 	}
 	if response.StatusCode != 200 {
 		log.Fatalf("got %d response status, want 200", response.StatusCode)
@@ -52,9 +52,9 @@ func TestDoPostRequest(t *testing.T) {
 	defer testEnv.TearDownTestEnv()
 	testEnv.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, "response")
+		fmt.Fprint(w, "response")
 
-		if r.Method != "POST" {
+		if r.Method != http.MethodPost {
 			t.Errorf("got %s method, want POST", r.Method)
 		}
 
@@ -82,12 +82,12 @@ func TestDoPostRequest(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	response, err := client.DoRequest(ctx, "POST", endpoint, bytes.NewReader(requestBody))
+	response, err := client.DoRequest(ctx, http.MethodPost, endpoint, bytes.NewReader(requestBody))
 	if err != nil {
 		log.Fatalf("unexpected error: %v", err)
 	}
 	if response.Body == nil {
-		log.Fatalf("response body is empty")
+		log.Fatal("response body is empty")
 	}
 	if response.StatusCode != 200 {
 		log.Fatalf("got %d response status, want 200", response.StatusCode)

--- a/selvpcclient/testutils/handlers.go
+++ b/selvpcclient/testutils/handlers.go
@@ -37,7 +37,7 @@ type HandleReqOpts struct {
 }
 
 // HandleReqWithoutBody provides the HTTP endpoint to test requests without body.
-func HandleReqWithoutBody(t *testing.T, opts HandleReqOpts) {
+func HandleReqWithoutBody(t *testing.T, opts *HandleReqOpts) {
 	opts.Mux.HandleFunc(opts.URL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(opts.Status)
@@ -52,7 +52,7 @@ func HandleReqWithoutBody(t *testing.T, opts HandleReqOpts) {
 }
 
 // HandleReqWithBody provides the HTTP endpoint to test requests with body.
-func HandleReqWithBody(t *testing.T, opts HandleReqOpts) {
+func HandleReqWithBody(t *testing.T, opts *HandleReqOpts) {
 	opts.Mux.HandleFunc(opts.URL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(opts.Status)

--- a/selvpcclient/testutils/handlers.go
+++ b/selvpcclient/testutils/handlers.go
@@ -9,30 +9,57 @@ import (
 	"testing"
 )
 
-// HandleReqWithoutBody provides the HTTP endpoint to test requests without body.
-func HandleReqWithoutBody(mux *http.ServeMux, url, rawResponse, method string, httpStatus int, callFlag *bool, t *testing.T) {
-	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(httpStatus)
-		fmt.Fprintf(w, rawResponse)
+// HandleReqOpts represents options for the testing utils package handlers.
+type HandleReqOpts struct {
+	// Mux represents HTTP Mux for a testing handler.
+	Mux *http.ServeMux
 
-		if r.Method != method {
-			t.Fatalf("expected %s method but got %s", method, r.Method)
+	// URL represents handler's HTTP URL.
+	URL string
+
+	// RawResponse represents raw string HTTP response that needs to be returned
+	// by the handler.
+	RawResponse string
+
+	// RawRequest represents raw string HTTP request that needs to be compared
+	// with the actual request that will be provided by the caller.
+	RawRequest string
+
+	// Method contains HTTP method that needs to be compared against real method
+	// provided by the caller.
+	Method string
+
+	// Status represents HTTP status that will be returned by the handler.
+	Status int
+
+	// CallFlag can be used to check if caller sent a request to a handler.
+	CallFlag *bool
+}
+
+// HandleReqWithoutBody provides the HTTP endpoint to test requests without body.
+func HandleReqWithoutBody(t *testing.T, opts HandleReqOpts) {
+	opts.Mux.HandleFunc(opts.URL, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(opts.Status)
+		fmt.Fprint(w, opts.RawResponse)
+
+		if r.Method != opts.Method {
+			t.Fatalf("expected %s method but got %s", opts.Method, r.Method)
 		}
 
-		*callFlag = true
+		*opts.CallFlag = true
 	})
 }
 
 // HandleReqWithBody provides the HTTP endpoint to test requests with body.
-func HandleReqWithBody(mux *http.ServeMux, url, rawResponse, rawRequest, method string, httpStatus int, callFlag *bool, t *testing.T) {
-	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+func HandleReqWithBody(t *testing.T, opts HandleReqOpts) {
+	opts.Mux.HandleFunc(opts.URL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(httpStatus)
-		fmt.Fprintf(w, rawResponse)
+		w.WriteHeader(opts.Status)
+		fmt.Fprint(w, opts.RawResponse)
 
-		if r.Method != method {
-			t.Fatalf("expected %s method but got %s", method, r.Method)
+		if r.Method != opts.Method {
+			t.Fatalf("expected %s method but got %s", opts.Method, r.Method)
 		}
 
 		b, err := ioutil.ReadAll(r.Body)
@@ -47,7 +74,7 @@ func HandleReqWithBody(mux *http.ServeMux, url, rawResponse, rawRequest, method 
 		}
 
 		var expectedRequest interface{}
-		err = json.Unmarshal([]byte(rawRequest), &expectedRequest)
+		err = json.Unmarshal([]byte(opts.RawRequest), &expectedRequest)
 		if err != nil {
 			t.Errorf("unable to unmarshal expected raw request: %v", err)
 		}
@@ -56,6 +83,6 @@ func HandleReqWithBody(mux *http.ServeMux, url, rawResponse, rawRequest, method 
 			t.Fatalf("expected %#v request, but got %#v", expectedRequest, actualRequest)
 		}
 
-		*callFlag = true
+		*opts.CallFlag = true
 	})
 }


### PR DESCRIPTION
Use standard HTTP method names from the `net/http` package.
Remove `emptyFmt` errors.
Refactor testutils handlers so it will use structure with parameters instead of many arguments in each handler. This structure is passed by pointer to prevent lots of copying.
