### PR TITLE
CI: run Gocritic with all checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ go:
 before_script:
   - go vet ./...
   - golint -set_exit_status ./...
-  - gocritic check-project --enable=all .
+  - gocritic check-project --enable=all -withExperimental -withOpinionated .
   - ./scripts/imports
   - ./scripts/format
 script:


### PR DESCRIPTION
Use "-withExperimental" and "-withOpinionated" arguments to enable
strict checking.
