### PR TITLE
Gocritic: fix structLitKeyOrder errors

### DIFF
--- a/selvpcclient/resell/v2/licenses/testing/fixtures.go
+++ b/selvpcclient/resell/v2/licenses/testing/fixtures.go
@@ -35,8 +35,6 @@ var TestGetLicenseResponse = &licenses.License{
 	ID:        123123,
 	ProjectID: "49338ac045f448e294b25d013f890317",
 	Region:    "ru-2",
-	Status:    "ACTIVE",
-	Type:      "license_windows_2012_standard",
 	Servers: []servers.Server{
 		{
 			ID:      "253b680c-89f6-4c85-afbf-c9a67c92d3fe",
@@ -45,6 +43,8 @@ var TestGetLicenseResponse = &licenses.License{
 			Updated: licenseServerTimeStamp,
 		},
 	},
+	Status: "ACTIVE",
+	Type:   "license_windows_2012_standard",
 }
 
 // TestListLicensesResponseRaw represents a raw response from the List request.

--- a/selvpcclient/resell/v2/projects/testing/fixtures.go
+++ b/selvpcclient/resell/v2/projects/testing/fixtures.go
@@ -92,9 +92,9 @@ var TestGetProjectSingleQuotaResponse = &projects.Project{
 			ResourceQuotasEntities: []quotas.ResourceQuotaEntity{
 				{
 					Region: "ru-1",
-					Used:   2,
-					Value:  10,
 					Zone:   "ru-1b",
+					Value:  10,
+					Used:   2,
 				},
 			},
 		},
@@ -259,9 +259,9 @@ var TestCreateProjectAutoQuotasResponse = &projects.Project{
 			ResourceQuotasEntities: []quotas.ResourceQuotaEntity{
 				{
 					Region: "ru-1",
-					Used:   2,
-					Value:  10,
 					Zone:   "ru-1b",
+					Value:  10,
+					Used:   2,
 				},
 			},
 		},
@@ -309,15 +309,15 @@ const TestUpdateProjectResponseRaw = `
 
 // TestUpdateProjectResponse represents the unmarshalled TestUpdateProjectResponseRaw response.
 var TestUpdateProjectResponse = &projects.Project{
-	ID:      "f9ede488e5f14bac8962d8c53d0af9f4",
-	Name:    "Project3",
-	URL:     "https://zzzzzz.selvpc.ru",
-	Enabled: true,
-	Theme: projects.Theme{
-		Logo:  "",
-		Color: "#581845",
-	},
+	ID:        "f9ede488e5f14bac8962d8c53d0af9f4",
+	Name:      "Project3",
+	URL:       "https://zzzzzz.selvpc.ru",
+	Enabled:   true,
 	CustomURL: "",
+	Theme: projects.Theme{
+		Color: "#581845",
+		Logo:  "",
+	},
 }
 
 // TestManyProjectsInvalidResponseRaw represents a raw invalid response with many projects.

--- a/selvpcclient/resell/v2/subnets/testing/fixtures.go
+++ b/selvpcclient/resell/v2/subnets/testing/fixtures.go
@@ -45,11 +45,11 @@ var TestGetSubnetResponse = &subnets.Subnet{
 			Updated: subnetServerTimeStamp,
 		},
 	},
+	Region:    "ru-3",
 	CIDR:      "203.0.113.0/24",
 	NetworkID: "8233f12e-c47e-4f1c-953a-1ecd322a7119",
-	ProjectID: "49338ac045f448e294b25d013f890317",
-	Region:    "ru-3",
 	SubnetID:  "94425a6e-19cd-412d-9710-ff40b34a78f4",
+	ProjectID: "49338ac045f448e294b25d013f890317",
 }
 
 // TestListSubnetsResponseRaw represents a raw response from the List request.
@@ -124,16 +124,16 @@ const TestCreateSubnetsOptsRaw = `
 var TestCreateSubnetsOpts = subnets.SubnetOpts{
 	Subnets: []subnets.SubnetOpt{
 		{
-			Type:         selvpcclient.IPv4,
-			PrefixLength: 29,
 			Region:       "ru-2",
 			Quantity:     1,
-		},
-		{
 			Type:         selvpcclient.IPv4,
 			PrefixLength: 29,
+		},
+		{
 			Region:       "ru-1",
 			Quantity:     1,
+			Type:         selvpcclient.IPv4,
+			PrefixLength: 29,
 		},
 	},
 }

--- a/selvpcclient/resell/v2/vrrpsubnets/testing/fixtures.go
+++ b/selvpcclient/resell/v2/vrrpsubnets/testing/fixtures.go
@@ -57,22 +57,22 @@ var TestGetVRRPSubnetResponse = &vrrpsubnets.VRRPSubnet{
 			Updated: vrrpSubnetServerTimeStamp,
 		},
 	},
-	CIDR:         "203.0.113.0/24",
-	ProjectID:    "49338ac045f448e294b25d013f890317",
 	MasterRegion: "ru-2",
 	SlaveRegion:  "ru-1",
+	CIDR:         "203.0.113.0/24",
 	Subnets: []subnets.Subnet{
 		{
+			Region:    "ru-1",
 			NetworkID: "8233f12e-c47e-4f1c-953a-1ecd322a7119",
 			SubnetID:  "94425a6e-19cd-412d-9710-ff40b34a78f4",
-			Region:    "ru-1",
 		},
 		{
+			Region:    "ru-2",
 			NetworkID: "e53c5abe-8b64-4a49-83f2-a51949d9294e",
 			SubnetID:  "649231cc-a17f-4c6b-8bf3-51a8871104c5",
-			Region:    "ru-2",
 		},
 	},
+	ProjectID: "49338ac045f448e294b25d013f890317",
 }
 
 // TestListVRRPSubnetsResponseRaw represents a raw response from the List request.
@@ -130,14 +130,14 @@ var TestListVRRPSubnetsResponse = []*vrrpsubnets.VRRPSubnet{
 		SlaveRegion:  "ru-1",
 		Subnets: []subnets.Subnet{
 			{
+				Region:    "ru-1",
 				NetworkID: "8233f12e-c47e-4f1c-953a-1ecd322a7119",
 				SubnetID:  "94425a6e-19cd-412d-9710-ff40b34a78f4",
-				Region:    "ru-1",
 			},
 			{
+				Region:    "ru-2",
 				NetworkID: "e53c5abe-8b64-4a49-83f2-a51949d9294e",
 				SubnetID:  "649231cc-a17f-4c6b-8bf3-51a8871104c5",
-				Region:    "ru-2",
 			},
 		},
 	},
@@ -214,14 +214,14 @@ var TestCreateVRRPSubnetsResponse = []*vrrpsubnets.VRRPSubnet{
 		SlaveRegion:  "ru-1",
 		Subnets: []subnets.Subnet{
 			{
+				Region:    "ru-1",
 				NetworkID: "8233f12e-c47e-4f1c-953a-1ecd322a7119",
 				SubnetID:  "94425a6e-19cd-412d-9710-ff40b34a78f4",
-				Region:    "ru-1",
 			},
 			{
+				Region:    "ru-2",
 				NetworkID: "e53c5abe-8b64-4a49-83f2-a51949d9294e",
 				SubnetID:  "649231cc-a17f-4c6b-8bf3-51a8871104c5",
-				Region:    "ru-2",
 			},
 		},
 	},


### PR DESCRIPTION
Ensure key order in unit tests.

For #97 
