### PR TITLE
HTTP client: use custom timeouts

### DIFF
--- a/selvpcclient/resell/v2/client.go
+++ b/selvpcclient/resell/v2/client.go
@@ -1,31 +1,29 @@
 package v2
 
 import (
-	"net/http"
-
 	"github.com/selectel/go-selvpcclient/selvpcclient"
 	"github.com/selectel/go-selvpcclient/selvpcclient/resell"
 )
 
 // APIVersion sets the version of the Resell client.
-const APIVersion = "v2"
+const (
+	APIVersion = "v2"
+)
 
 // NewV2ResellClient initializes a new Resell client for the V2 API.
 func NewV2ResellClient(tokenID string) *selvpcclient.ServiceClient {
-	resellClient := &selvpcclient.ServiceClient{
-		HTTPClient: &http.Client{},
+	return &selvpcclient.ServiceClient{
+		HTTPClient: selvpcclient.NewHTTPClient(),
 		Endpoint:   resell.Endpoint + "/" + APIVersion,
 		TokenID:    tokenID,
 		UserAgent:  resell.UserAgent,
 	}
-
-	return resellClient
 }
 
 // NewV2ResellClientWithEndpoint initializes a new Resell client for the V2 API with a custom endpoint.
 func NewV2ResellClientWithEndpoint(tokenID, endpoint string) *selvpcclient.ServiceClient {
 	resellClient := &selvpcclient.ServiceClient{
-		HTTPClient: &http.Client{},
+		HTTPClient: selvpcclient.NewHTTPClient(),
 		Endpoint:   endpoint,
 		TokenID:    tokenID,
 		UserAgent:  resell.UserAgent,

--- a/selvpcclient/selvpc.go
+++ b/selvpcclient/selvpc.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -28,7 +29,39 @@ const (
 
 	// DefaultUserAgent contains basic user agent that will be used in queries.
 	DefaultUserAgent = AppName + "/" + AppVersion
+
+	// defaultHTTPTimeout represents default timeout (in seconds) for HTTP
+	// requests.
+	defaultHTTPTimeout = 10
+
+	// defaultDialTimeout represents default timeout (in seconds) for HTTP
+	// connection establishments.
+	defaultDialTimeout = 5
+
+	// defaultTLSHandshakeTimeout represents default timeout (in seconds) for
+	// TSL handshake timeout.
+	defaultTLSHandshakeTimeout = 5
 )
+
+// NewHTTPClient returns a reference to an initialized HTTP client with
+// configured timeouts.
+func NewHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   time.Second * defaultHTTPTimeout,
+		Transport: newHTTPTransport(),
+	}
+}
+
+// newHTTPTransport returns a reference to an initialized HTTP transport with
+// configured timeouts.
+func newHTTPTransport() *http.Transport {
+	return &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout: time.Second * defaultDialTimeout,
+		}).Dial,
+		TLSHandshakeTimeout: time.Second * defaultTLSHandshakeTimeout,
+	}
+}
 
 // ServiceClient stores details that are needed to work with different Selectel VPC APIs.
 type ServiceClient struct {


### PR DESCRIPTION
Use customized timeouts for HTTP client instead of default Go net/http timeouts.

For #101 
