### PR TITLE
SelVPC HTTP client: set higher defaultHTTPTimeout

### DIFF
--- a/selvpcclient/selvpc.go
+++ b/selvpcclient/selvpc.go
@@ -32,7 +32,7 @@ const (
 
 	// defaultHTTPTimeout represents default timeout (in seconds) for HTTP
 	// requests.
-	defaultHTTPTimeout = 10
+	defaultHTTPTimeout = 40
 
 	// defaultDialTimeout represents default timeout (in seconds) for HTTP
 	// connection establishments.


### PR DESCRIPTION
Use 40 second for the defaultHTTPTimeout constant.

For #101 
