### PR TITLE
Resell V2 - add roles list method

### DIFF
--- a/selvpcclient/resell/v2/roles/doc.go
+++ b/selvpcclient/resell/v2/roles/doc.go
@@ -2,6 +2,16 @@
 Package roles provides the ability to retrieve and manage roles through the
 Resell v2 API.
 
+Example of getting roles in the current domain
+
+  allRoles, _, err = roles.List(context, resellClient)
+  if err != nil {
+    log.Fatal(err)
+  }
+  for _, myRole := range allRoles {
+    fmt.Println(myRole)
+  }
+
 Example of getting roles in the specified project
 
   allRoles, _, err := roles.ListProject(context, resellClient, projectID)

--- a/selvpcclient/resell/v2/roles/requests.go
+++ b/selvpcclient/resell/v2/roles/requests.go
@@ -12,6 +12,29 @@ import (
 
 const resourceURL = "roles"
 
+// List returns all roles in the current domain.
+func List(ctx context.Context, client *selvpcclient.ServiceClient) ([]*Role, *selvpcclient.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, resourceURL}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if responseResult.Err != nil {
+		return nil, responseResult, responseResult.Err
+	}
+
+	//Extract roles from the response body.
+	var result struct {
+		Roles []*Role `json:"roles"`
+	}
+	err = responseResult.ExtractResult(&result)
+	if err != nil {
+		return nil, responseResult, err
+	}
+
+	return result.Roles, responseResult, nil
+}
+
 // ListProject returns all roles in the specified project.
 func ListProject(ctx context.Context, client *selvpcclient.ServiceClient, id string) ([]*Role, *selvpcclient.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, resourceURL, "projects", id}, "/")

--- a/selvpcclient/resell/v2/roles/testing/fixtures.go
+++ b/selvpcclient/resell/v2/roles/testing/fixtures.go
@@ -2,6 +2,26 @@ package testing
 
 import "github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/roles"
 
+// TestListResponseRaw represents a raw response from List requests.
+const TestListResponseRaw = `
+{
+    "roles": [
+        {
+            "project_id": "49338ac045f448e294b25d013f890317",
+            "user_id": "b006a55e3a904472824061d64d61be75"
+        },
+        {
+            "project_id": "49338ac045f448e294b25d013f890317",
+            "user_id": "763eecfaeb0c8e9b76ab12a82eb4c11"
+        },
+        {
+            "project_id": "d7452adc9769422a908edfd2281d7c55",
+            "user_id": "763eecfaeb0c8e9b76ab12a82eb4c11"
+        }
+    ]
+}
+`
+
 // TestListProjectResponseRaw represents a raw response from ListProject requests.
 const TestListProjectResponseRaw = `
 {


### PR DESCRIPTION
Add method to list all roles in the current domain.
Add tests and doc example.

For #107 