### PR TITLE
Resell V2: fix Cross-region subnet ProjectID

### DIFF
--- a/selvpcclient/resell/v2/crossregionsubnets/schemas.go
+++ b/selvpcclient/resell/v2/crossregionsubnets/schemas.go
@@ -19,6 +19,9 @@ type CrossRegionSubnet struct {
 	// Status shows if cross-region subnet is used.
 	Status string `json:"status"`
 
+	// ProjectID represents an associated Identity service project.
+	ProjectID string `json:"project_id"`
+
 	// Servers contains info about servers to which cross-region subnet is associated to.
 	Servers []servers.Server `json:"servers"`
 

--- a/selvpcclient/resell/v2/crossregionsubnets/testing/fixtures.go
+++ b/selvpcclient/resell/v2/crossregionsubnets/testing/fixtures.go
@@ -16,6 +16,7 @@ const TestGetCrossRegionSubnetResponseRaw = `
 		"cidr": "192.168.200.0/24",
 		"vlan_id": 1003,
 		"status": "ACTIVE",
+        "project_id": "b63ab68796e34858befb8fa2a8b1e12a",
 		"servers": [
 			{
 				"status": "ACTIVE",
@@ -35,7 +36,6 @@ const TestGetCrossRegionSubnetResponseRaw = `
 				"id": 10,
 				"vlan_id": 1003,
 				"cidr": "192.168.200.0/24",
-				"project_id": "b63ab68796e34858befb8fa2a8b1e12a",
 				"network_id": "78c1cbe1-c34d-4685-be2d-a877a1b1dec4",
 				"subnet_id": "7db1255f-2545-4b8a-9446-22608c0f6cb8",
 				"region": "ru-1",
@@ -45,7 +45,6 @@ const TestGetCrossRegionSubnetResponseRaw = `
 				"id": 20,
 				"vlan_id": 1003,
 				"cidr": "192.168.200.0/24",
-				"project_id": "b63ab68796e34858befb8fa2a8b1e12a",
 				"network_id": "67f7ab15-9424-4b50-999a-1c4de12372ec",
 				"subnet_id": "66ee047b-c699-4d62-9b64-363d2d77f021",
 				"region": "ru-3",
@@ -60,10 +59,11 @@ var crossregionSubnetServerTimeStamp, _ = time.Parse(time.RFC3339, "2019-01-04T0
 
 // TestGetCrossRegionSubnetResponse represents an unmarshalled TestGetCrossRegionSubnetResponseRaw.
 var TestGetCrossRegionSubnetResponse = &crossregionsubnets.CrossRegionSubnet{
-	ID:     12,
-	CIDR:   "192.168.200.0/24",
-	VLANID: 1003,
-	Status: "ACTIVE",
+	ID:        12,
+	CIDR:      "192.168.200.0/24",
+	VLANID:    1003,
+	Status:    "ACTIVE",
+	ProjectID: "b63ab68796e34858befb8fa2a8b1e12a",
 	Servers: []servers.Server{
 		{
 			ID:      "22170dcf-2e58-49b7-9115-951b84d366f6",
@@ -85,7 +85,6 @@ var TestGetCrossRegionSubnetResponse = &crossregionsubnets.CrossRegionSubnet{
 			CIDR:          "192.168.200.0/24",
 			NetworkID:     "78c1cbe1-c34d-4685-be2d-a877a1b1dec4",
 			SubnetID:      "7db1255f-2545-4b8a-9446-22608c0f6cb8",
-			ProjectID:     "b63ab68796e34858befb8fa2a8b1e12a",
 			VLANID:        1003,
 			VTEPIPAddress: "10.10.0.101",
 		},
@@ -95,7 +94,6 @@ var TestGetCrossRegionSubnetResponse = &crossregionsubnets.CrossRegionSubnet{
 			CIDR:          "192.168.200.0/24",
 			NetworkID:     "67f7ab15-9424-4b50-999a-1c4de12372ec",
 			SubnetID:      "66ee047b-c699-4d62-9b64-363d2d77f021",
-			ProjectID:     "b63ab68796e34858befb8fa2a8b1e12a",
 			VLANID:        1003,
 			VTEPIPAddress: "10.10.0.201",
 		},
@@ -111,6 +109,7 @@ const TestListCrossRegionSubnetsResponseRaw = `
 			"cidr": "192.168.200.0/24",
 			"vlan_id": 1003,
 			"status": "ACTIVE",
+			"project_id": "b63ab68796e34858befb8fa2a8b1e12a",
 			"servers": [
 				{
 					"status": "ACTIVE",
@@ -130,7 +129,6 @@ const TestListCrossRegionSubnetsResponseRaw = `
 					"id": 10,
 					"vlan_id": 1003,
 					"cidr": "192.168.200.0/24",
-					"project_id": "b63ab68796e34858befb8fa2a8b1e12a",
 					"network_id": "78c1cbe1-c34d-4685-be2d-a877a1b1dec4",
 					"subnet_id": "7db1255f-2545-4b8a-9446-22608c0f6cb8",
 					"region": "ru-1",
@@ -140,7 +138,6 @@ const TestListCrossRegionSubnetsResponseRaw = `
 					"id": 20,
 					"vlan_id": 1003,
 					"cidr": "192.168.200.0/24",
-					"project_id": "b63ab68796e34858befb8fa2a8b1e12a",
 					"network_id": "67f7ab15-9424-4b50-999a-1c4de12372ec",
 					"subnet_id": "66ee047b-c699-4d62-9b64-363d2d77f021",
 					"region": "ru-3",
@@ -155,10 +152,11 @@ const TestListCrossRegionSubnetsResponseRaw = `
 // TestListCrossRegionSubnetsResponse represents an unmarshalled TestListCrossRegionSubnetsResponseRaw
 var TestListCrossRegionSubnetsResponse = []*crossregionsubnets.CrossRegionSubnet{
 	{
-		ID:     12,
-		CIDR:   "192.168.200.0/24",
-		VLANID: 1003,
-		Status: "ACTIVE",
+		ID:        12,
+		CIDR:      "192.168.200.0/24",
+		VLANID:    1003,
+		Status:    "ACTIVE",
+		ProjectID: "b63ab68796e34858befb8fa2a8b1e12a",
 		Servers: []servers.Server{
 			{
 				ID:      "22170dcf-2e58-49b7-9115-951b84d366f6",
@@ -180,7 +178,6 @@ var TestListCrossRegionSubnetsResponse = []*crossregionsubnets.CrossRegionSubnet
 				CIDR:          "192.168.200.0/24",
 				NetworkID:     "78c1cbe1-c34d-4685-be2d-a877a1b1dec4",
 				SubnetID:      "7db1255f-2545-4b8a-9446-22608c0f6cb8",
-				ProjectID:     "b63ab68796e34858befb8fa2a8b1e12a",
 				VLANID:        1003,
 				VTEPIPAddress: "10.10.0.101",
 			},
@@ -190,7 +187,6 @@ var TestListCrossRegionSubnetsResponse = []*crossregionsubnets.CrossRegionSubnet
 				CIDR:          "192.168.200.0/24",
 				NetworkID:     "67f7ab15-9424-4b50-999a-1c4de12372ec",
 				SubnetID:      "66ee047b-c699-4d62-9b64-363d2d77f021",
-				ProjectID:     "b63ab68796e34858befb8fa2a8b1e12a",
 				VLANID:        1003,
 				VTEPIPAddress: "10.10.0.201",
 			},
@@ -245,12 +241,12 @@ const TestCreateCrossRegionSubnetsResponseRaw = `
 			"cidr": "192.168.200.0/24",
 			"vlan_id": 1003,
 			"status": "DOWN",
+			"project_id": "b63ab68796e34858befb8fa2a8b1e12a",
 			"subnets": [
 				{
 					"id": 10,
 					"vlan_id": 1003,
 					"cidr": "192.168.200.0/24",
-					"project_id": "b63ab68796e34858befb8fa2a8b1e12a",
 					"network_id": "78c1cbe1-c34d-4685-be2d-a877a1b1dec4",
 					"subnet_id": "7db1255f-2545-4b8a-9446-22608c0f6cb8",
 					"region": "ru-1",
@@ -260,7 +256,6 @@ const TestCreateCrossRegionSubnetsResponseRaw = `
 					"id": 20,
 					"vlan_id": 1003,
 					"cidr": "192.168.200.0/24",
-					"project_id": "b63ab68796e34858befb8fa2a8b1e12a",
 					"network_id": "67f7ab15-9424-4b50-999a-1c4de12372ec",
 					"subnet_id": "66ee047b-c699-4d62-9b64-363d2d77f021",
 					"region": "ru-3",
@@ -275,10 +270,11 @@ const TestCreateCrossRegionSubnetsResponseRaw = `
 // TestCreateCrossRegionSubnetsResponse represents an unmarshalled TestCreateCrossRegionSubnetsResponseRaw
 var TestCreateCrossRegionSubnetsResponse = []*crossregionsubnets.CrossRegionSubnet{
 	{
-		ID:     12,
-		CIDR:   "192.168.200.0/24",
-		VLANID: 1003,
-		Status: "DOWN",
+		ID:        12,
+		CIDR:      "192.168.200.0/24",
+		VLANID:    1003,
+		Status:    "DOWN",
+		ProjectID: "b63ab68796e34858befb8fa2a8b1e12a",
 		Subnets: []subnets.Subnet{
 			{
 				ID:            10,
@@ -286,7 +282,6 @@ var TestCreateCrossRegionSubnetsResponse = []*crossregionsubnets.CrossRegionSubn
 				CIDR:          "192.168.200.0/24",
 				NetworkID:     "78c1cbe1-c34d-4685-be2d-a877a1b1dec4",
 				SubnetID:      "7db1255f-2545-4b8a-9446-22608c0f6cb8",
-				ProjectID:     "b63ab68796e34858befb8fa2a8b1e12a",
 				VLANID:        1003,
 				VTEPIPAddress: "10.10.0.101",
 			},
@@ -296,7 +291,6 @@ var TestCreateCrossRegionSubnetsResponse = []*crossregionsubnets.CrossRegionSubn
 				CIDR:          "192.168.200.0/24",
 				NetworkID:     "67f7ab15-9424-4b50-999a-1c4de12372ec",
 				SubnetID:      "66ee047b-c699-4d62-9b64-363d2d77f021",
-				ProjectID:     "b63ab68796e34858befb8fa2a8b1e12a",
 				VLANID:        1003,
 				VTEPIPAddress: "10.10.0.201",
 			},


### PR DESCRIPTION
Remove ProjectID field from associated subnets and add it into parent
Cross-region subnet.
