### PR TITLE
Add support enpoint for revoke token by its id

### DIFF
--- a/selvpcclient/resell/v2/tokens/doc.go
+++ b/selvpcclient/resell/v2/tokens/doc.go
@@ -22,5 +22,12 @@ Example of creating a domain-scoped token
     log.Fatal(err)
   }
   fmt.Println(token.ID)
+
+Example of deleting a token
+
+  _, err = tokens.Delete(context, resellClient, token.ID)
+  if err != nil {
+    log.Fatal(err)
+  }
 */
 package tokens

--- a/selvpcclient/resell/v2/tokens/requests.go
+++ b/selvpcclient/resell/v2/tokens/requests.go
@@ -44,3 +44,16 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, createOpts 
 
 	return result.Token, responseResult, nil
 }
+
+// Delete a user owned Identity token by its id.
+func Delete(ctx context.Context, client *selvpcclient.ServiceClient, id string) (*selvpcclient.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, resourceURL, id}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if responseResult.Err != nil {
+		err = responseResult.Err
+	}
+	return responseResult, err
+}


### PR DESCRIPTION
Support for enpoints _`HTTP DELETE`_ `tokens/<TOKEN_ID>`