### PR TITLE
Resell V2: use *string in quotas.ResourceQuotaOpts

### DIFF
--- a/selvpcclient/resell/v2/quotas/requests_opts.go
+++ b/selvpcclient/resell/v2/quotas/requests_opts.go
@@ -19,10 +19,10 @@ type QuotaOpts struct {
 // in the specific region and zone.
 type ResourceQuotaOpts struct {
 	// Region contains the quota region data.
-	Region string `json:"region,omitempty"`
+	Region *string `json:"region"`
 
 	// Zone contains the quota zone data.
-	Zone string `json:"zone,omitempty"`
+	Zone *string `json:"zone"`
 
 	// Value contans value of resource quota in the specific region and zone.
 	Value *int `json:"value"`

--- a/selvpcclient/resell/v2/quotas/testing/fixtures.go
+++ b/selvpcclient/resell/v2/quotas/testing/fixtures.go
@@ -396,13 +396,6 @@ const TestQuotasInvalidResponseRaw = `
 }
 `
 
-// TestUpdateQuotasInvalidOptsRaw represents a raw request body without quotas.
-const TestUpdateQuotasInvalidOptsRaw = `
-{
-    "quotas": {}
-}
-`
-
 // TestUpdateQuotasInvalidOpts represents update opts without quotas.
 var TestUpdateQuotasInvalidOpts = quotas.UpdateProjectQuotasOpts{
 	QuotasOpts: []quotas.QuotaOpts{},

--- a/selvpcclient/resell/v2/quotas/testing/fixtures.go
+++ b/selvpcclient/resell/v2/quotas/testing/fixtures.go
@@ -255,7 +255,11 @@ var TestGetProjectQuotasResponseSingle = []*quotas.Quota{
 	},
 }
 
-var ramQuotaValue = 64000
+var (
+	ramQuotaRegion = "ru-2"
+	ramQuotaZone   = "ru-2a"
+	ramQuotaValue  = 64000
+)
 
 // TestUpdateQuotasOpts represents options for the UpdateProjectQuotas request.
 var TestUpdateQuotasOpts = quotas.UpdateProjectQuotasOpts{
@@ -264,8 +268,8 @@ var TestUpdateQuotasOpts = quotas.UpdateProjectQuotasOpts{
 			Name: "compute_ram",
 			ResourceQuotasOpts: []quotas.ResourceQuotaOpts{
 				{
-					Region: "ru-2",
-					Zone:   "ru-2a",
+					Region: &ramQuotaRegion,
+					Zone:   &ramQuotaZone,
 					Value:  &ramQuotaValue,
 				},
 			},
@@ -312,6 +316,66 @@ var TestUpdateProjectQuotasResponse = []*quotas.Quota{
 				Region: "ru-2",
 				Zone:   "ru-2a",
 				Value:  64000,
+			},
+		},
+	},
+}
+
+// TestUpdateQuotasOptsNilLocationParams represents options for the UpdateProjectQuotas request
+// with "null" in region and zone.
+var TestUpdateQuotasOptsNilLocationParams = quotas.UpdateProjectQuotasOpts{
+	QuotasOpts: []quotas.QuotaOpts{
+		{
+			Name: "compute_ram",
+			ResourceQuotasOpts: []quotas.ResourceQuotaOpts{
+				{
+					Value: &ramQuotaValue,
+				},
+			},
+		},
+	},
+}
+
+// TestUpdateQuotasOptsNilLocationParamsRaw represents unmarshalled options for the
+// UpdateProjectQuotas request with "null" in region and zone.
+const TestUpdateQuotasOptsRawNilLocationParams = `
+{
+    "quotas": {
+        "compute_ram": [
+            {
+                "region": null,
+                "value": 64000,
+                "zone": null
+            }
+        ]
+    }
+}
+`
+
+// TestUpdateProjectQuotasResponseRawNilLocationParams represents a raw response from the
+// UpdateProjectQuotas request with "null" in region and zone.
+const TestUpdateProjectQuotasResponseRawNilLocationParams = `
+{
+    "quotas": {
+        "compute_ram": [
+            {
+                "region": null,
+                "value": 64000,
+                "zone": null
+            }
+        ]
+    }
+}
+`
+
+// TestUpdateProjectQuotasResponseNilLocationParams represents the unmarshalled
+// TestUpdateProjectQuotasResponseRaw response with "null" in region and zone.
+var TestUpdateProjectQuotasResponseNilLocationParams = []*quotas.Quota{
+	{
+		Name: "compute_ram",
+		ResourceQuotasEntities: []quotas.ResourceQuotaEntity{
+			{
+				Value: 64000,
 			},
 		},
 	},

--- a/selvpcclient/resell/v2/quotas/testing/requests_test.go
+++ b/selvpcclient/resell/v2/quotas/testing/requests_test.go
@@ -647,6 +647,39 @@ func TestUpdateProjectQuotas(t *testing.T) {
 	}
 }
 
+func TestUpdateProjectQuotasNilLocation(t *testing.T) {
+	endpointCalled := false
+
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.NewTestResellV2Client()
+	testutils.HandleReqWithBody(t, &testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/resell/v2/quotas/projects/c83243b3c18a4d109a5f0fe45336af85",
+		RawResponse: TestUpdateProjectQuotasResponseRawNilLocationParams,
+		RawRequest:  TestUpdateQuotasOptsRawNilLocationParams,
+		Method:      http.MethodPatch,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
+
+	ctx := context.Background()
+	updateOpts := TestUpdateQuotasOptsNilLocationParams
+	actualResponse, _, err := quotas.UpdateProjectQuotas(ctx, testEnv.Client, "c83243b3c18a4d109a5f0fe45336af85", updateOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedResponse := TestUpdateProjectQuotasResponseNilLocationParams
+
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if !reflect.DeepEqual(actualResponse, expectedResponse) {
+		t.Fatalf("expected %#v, but got %#v", actualResponse, expectedResponse)
+	}
+}
+
 func TestUpdateProjectQuotasHTTPError(t *testing.T) {
 	endpointCalled := false
 


### PR DESCRIPTION
Use *string in region and zone since the Resell V2 API wants them to be always set instead of omitting them.

Remove quotas/testing.TestUpdateQuotasInvalidOptsRaw.

For #145
