### PR TITLE
Resell V2 Projects: fix tests with quotas

### DIFF
--- a/scripts/gotest.sh
+++ b/scripts/gotest.sh
@@ -2,10 +2,19 @@
 
 echo "==> Running go test and creating a coverage profile..."
 i=0
+failed=0
 for testingpkg in $(go list ./selvpcclient/.../testing); do
   coverpkg=${testingpkg::-8}
   go test -v -covermode count -coverprofile "./${i}.coverprofile" -coverpkg $coverpkg $testingpkg
+  if [ $? -eq 1 ]; then
+     failed+=1
+  fi
   ((i++))
 done
 gocovmerge $(ls ./*.coverprofile) > coverage.out
 rm *.coverprofile
+
+if ((failed>0)); then
+  exit 1
+fi
+exit 0

--- a/selvpcclient/resell/v2/projects/testing/fixtures.go
+++ b/selvpcclient/resell/v2/projects/testing/fixtures.go
@@ -159,7 +159,8 @@ const TestCreateProjectOptsRaw = `
             "image_gigabytes": [
                 {
                     "region": "ru-1",
-                    "value": 12
+                    "value": 12,
+                    "zone": null
                 }
             ]
         }
@@ -167,7 +168,10 @@ const TestCreateProjectOptsRaw = `
 }
 `
 
-var imageGigabytesValue = 12
+var (
+	regionValue         = "ru-1"
+	imageGigabytesValue = 12
+)
 
 // TestCreateProjectOpts represent options for the Create request.
 var TestCreateProjectOpts = projects.CreateOpts{
@@ -177,7 +181,7 @@ var TestCreateProjectOpts = projects.CreateOpts{
 			Name: "image_gigabytes",
 			ResourceQuotasOpts: []quotas.ResourceQuotaOpts{
 				{
-					Region: "ru-1",
+					Region: &regionValue,
 					Value:  &imageGigabytesValue,
 				},
 			},


### PR DESCRIPTION
Fix empty quotas in fixtures.

Check if go test command is failed to select a valid exit code.