### PR TITLE
Update and reconfigure golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,47 @@
+run:
+  deadline: 5m
+
 linters:
   fast: false
-  enable-all: true
-  disable:
-    - bodyclose
-    - gomnd
-    - dupl
-    - gochecknoglobals
-    - gosec
-    - lll
-    - wsl
-    - testpackage
+  enable:
+    - asciicheck
+    - deadcode
+    - depguard
+    - dogsled
+    - errcheck
+    - exportloopref
+    - gci
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - golint
+    - gomodguard
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - maligned
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unused
+    - varcheck
+    - whitespace

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 install:
   - go get github.com/mattn/goveralls
   - go get github.com/wadey/gocovmerge
-  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
 go:
   - "1.13"
   - "1.14"

--- a/selvpcclient/resell/v2/keypairs/requests.go
+++ b/selvpcclient/resell/v2/keypairs/requests.go
@@ -41,7 +41,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, createOpts 
 	type nestedCreateOpts struct {
 		Keypair KeypairOpts `json:"keypair"`
 	}
-	var createKeypairOpts = nestedCreateOpts{
+	createKeypairOpts := nestedCreateOpts{
 		Keypair: createOpts,
 	}
 	requestBody, err := json.Marshal(&createKeypairOpts)

--- a/selvpcclient/resell/v2/roles/requests.go
+++ b/selvpcclient/resell/v2/roles/requests.go
@@ -23,7 +23,7 @@ func List(ctx context.Context, client *selvpcclient.ServiceClient) ([]*Role, *se
 		return nil, responseResult, responseResult.Err
 	}
 
-	//Extract roles from the response body.
+	// Extract roles from the response body.
 	var result struct {
 		Roles []*Role `json:"roles"`
 	}

--- a/selvpcclient/resell/v2/traffic/testing/fixtures.go
+++ b/selvpcclient/resell/v2/traffic/testing/fixtures.go
@@ -54,8 +54,10 @@ const TestGetTrafficUsedRaw = `
 }
 `
 
-var trafficStartTimeStamp, _ = time.Parse(selvpcclient.RFC3339NoZ, "2018-04-01T00:00:00")
-var trafficStopTimeStamp, _ = time.Parse(selvpcclient.RFC3339NoZ, "2018-04-30T23:59:59")
+var (
+	trafficStartTimeStamp, _ = time.Parse(selvpcclient.RFC3339NoZ, "2018-04-01T00:00:00")
+	trafficStopTimeStamp, _  = time.Parse(selvpcclient.RFC3339NoZ, "2018-04-30T23:59:59")
+)
 
 // TestGetTrafficUsed represents the unmarshalled TestGetTrafficUsedRaw response.
 var TestGetTrafficUsed = &traffic.DomainTraffic{


### PR DESCRIPTION
Use Golangci-lint v1.30.0 in Travis CI.

Remove deprecated enable-all configuration from .golangci.yml.

Fix issues with gofumpt linter.
