### PR TITLE
Add keypairs list opts

### DIFF
--- a/.github/workflows/secure.yml
+++ b/.github/workflows/secure.yml
@@ -1,6 +1,10 @@
 name: Secure
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   # Sample GitHub Actions:
@@ -17,7 +21,7 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v4
-      - run: semgrep scan --sarif --output=semgrep.sarif --error --severity=WARNING
+      - run: semgrep scan --sarif --output=semgrep.sarif --error
         env:
           SEMGREP_RULES: >-
             p/command-injection

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,6 +1,10 @@
 name: Verify
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   tests:

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,4 @@
+*/testing/*_test.go
+*/testing/fixtures.go
+README.md
+selvpcclient/doc.go

--- a/selvpcclient/resell/v2/keypairs/requests_opts.go
+++ b/selvpcclient/resell/v2/keypairs/requests_opts.go
@@ -16,3 +16,10 @@ type KeypairOpts struct {
 	// this keypair.
 	UserID string `json:"user_id"`
 }
+
+// ListOpts represents options for the keypair ListWithFilter request.
+type ListOpts struct {
+	// UserID contains an ID of an OpenStack Identity service user that owns
+	// this keypair.
+	UserID string `url:"user_id"`
+}


### PR DESCRIPTION
Added the ability to pass user_id as a filter to speed up the key list query.

Also fix GitHub Actions:
 - enable for PR from fork
 - add .semgrepignore for tests
 - remove wrong --severity flag for semgrep