### PR TITLE
Add ability to set filters to GetProjectQuotas method

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
 
 linters:
   fast: false
@@ -51,4 +51,7 @@ linters-settings:
   goimports:
     local-prefixes: github.com/selectel/go-selvpcclient
   gci:
-    local-prefixes: github.com/selectel/go-selvpcclient
+    sections:
+      - standard
+      - default
+      - prefix(github.com/selectel/go-selvpcclient)

--- a/selvpcclient/quotamanager/quotas/testing/fixtures.go
+++ b/selvpcclient/quotamanager/quotas/testing/fixtures.go
@@ -62,6 +62,26 @@ const TestGetProjectQuotasResponseSingleRaw = `
 }
 `
 
+// TestGetProjectQuotasResponseSingleRaw represents a raw response with a single quota from the GetProject request.
+const TestGetProjectQuotasResponseFilteredRaw = `
+{
+    "quotas": {
+        "compute_ram": [
+            {
+                "value": 51200,
+                "zone": "ru-1a"
+            }
+        ],
+        "compute_cores": [
+            {
+                "value": 300,
+                "zone": "ru-1a"
+            }
+        ]
+    }
+}
+`
+
 // TestGetProjectQuotasResponseSingle represents the unmarshalled TestGetProjectQuotasResponseSingleRaw response.
 var TestGetProjectQuotasResponseSingle = []*quotas.Quota{
 	{
@@ -70,6 +90,30 @@ var TestGetProjectQuotasResponseSingle = []*quotas.Quota{
 			{
 				Zone:  "ru-1a",
 				Value: 51200,
+			},
+		},
+		ResourceQuotasErrors: []quotas.ResourceError{},
+	},
+}
+
+// TestGetProjectQuotasResponseFiltered represents the unmarshalled TestGetProjectQuotasResponseFilteredRaw response.
+var TestGetProjectQuotasResponseFiltered = []*quotas.Quota{
+	{
+		Name: "compute_ram",
+		ResourceQuotasEntities: []quotas.ResourceQuotaEntity{
+			{
+				Zone:  "ru-1a",
+				Value: 51200,
+			},
+		},
+		ResourceQuotasErrors: []quotas.ResourceError{},
+	},
+	{
+		Name: "compute_cores",
+		ResourceQuotasEntities: []quotas.ResourceQuotaEntity{
+			{
+				Zone:  "ru-1a",
+				Value: 300,
 			},
 		},
 		ResourceQuotasErrors: []quotas.ResourceError{},


### PR DESCRIPTION
Добавлена возможность указывать нужные ресурсы при вызове `quotas.GetProjectQuotas`  с помощью `quotas.WithResourceFilter`, например:
```
quotas.GetProjectQuotas(
       client, 
       "projectID", 
       "region",
       quotas.WithResourceFilter("resource_name1"),
       quotas.WithResourceFilter("resource_name2"),
	)
```