### PR TITLE
feat: add user-agent to options of client constructor

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,4 +1,5 @@
 */testing/*_test.go
 */testing/fixtures.go
+selvpcclient/testutils/*.go
 README.md
 selvpcclient/doc.go

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ func main() {
   Context:    ctx,
   DomainName: "999999",
   AuthRegion: "<pool>",
-  AuthURL:     "https://cloud.api.selcloud.ru/identity/v3/",
+  AuthURL:    "https://cloud.api.selcloud.ru/identity/v3/",
   Username:   "admin",
   Password:   "m1-sup3r-p@ssw0rd-p3w-p3w",
+  UserAgent:  "my-test-app/0.0.0",
  }
 
  client, err := selvpcclient.NewClient(options)

--- a/selvpcclient/clients/services/serviceclient.go
+++ b/selvpcclient/clients/services/serviceclient.go
@@ -81,9 +81,7 @@ func NewServiceClient(options *ServiceClientOptions) (*gophercloud.ServiceClient
 	serviceClient.HTTPClient = *httpClient
 
 	if options.UserAgent != "" {
-		userAgent := gophercloud.UserAgent{}
-		userAgent.Prepend(options.UserAgent)
-		serviceClient.UserAgent = userAgent
+		serviceClient.UserAgent.Prepend(options.UserAgent)
 	}
 
 	return serviceClient, nil

--- a/selvpcclient/selvpc.go
+++ b/selvpcclient/selvpc.go
@@ -60,6 +60,9 @@ type ClientOptions struct {
 	// Used in private clouds to issue a token not from owned domain.
 	// If this field is not set, then it will be equal to the value of DomainName.
 	UserDomainName string
+
+	// Optional field for specifying your User-Agent.
+	UserAgent string
 }
 
 func NewClient(options *ClientOptions) (*Client, error) {
@@ -88,6 +91,11 @@ func NewClient(options *ClientOptions) (*Client, error) {
 		return nil, fmt.Errorf("validation error: %w: %s", errRequiredClientOptions, strings.Join(requiredAbsent, ", "))
 	}
 
+	userAgent := fmt.Sprintf("%s/%s", AppName, findModuleVersion())
+	if options.UserAgent != "" {
+		userAgent = fmt.Sprintf("%s %s", options.UserAgent, userAgent)
+	}
+
 	serviceClientOptions := clientservices.ServiceClientOptions{
 		DomainName:     options.DomainName,
 		Username:       options.Username,
@@ -96,7 +104,7 @@ func NewClient(options *ClientOptions) (*Client, error) {
 		AuthRegion:     options.AuthRegion,
 		ProjectID:      options.ProjectID,
 		UserDomainName: options.UserDomainName,
-		UserAgent:      fmt.Sprintf("%s/%s", AppName, findModuleVersion()),
+		UserAgent:      userAgent,
 	}
 
 	serviceClient, err := clientservices.NewServiceClient(&serviceClientOptions)


### PR DESCRIPTION
Constructor: 
```golang
options := &selvpcclient.ClientOptions{
    ...
    UserAgent:  "my-test-app/0.0.0",
    ...
}
```

User-Agent from access.log:
```bash
my-test-app/0.0.0 go-selvpcclient/(devel) gophercloud/v1.10.0
```
